### PR TITLE
Adjust GOD gate overrides and add rubric diagnostics

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from fastapi import FastAPI, HTTPException, Body
+from fastapi import FastAPI, HTTPException, Body, Query, Response
+from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import uuid, os, json, time, pathlib, typing as t
@@ -28,6 +29,9 @@ _load_azure_from_json()
 # ---- Engine imports ----
 from skill_core.engine import AdaptiveSession
 from skill_core.types import Answer
+from skill_core.plan import generate_plan
+from skill_core.config import load_config, AUDIT_EXPORT_ENABLED, GLOBAL_STEP_CAP
+from skill_core.audit_export import to_json as audit_to_json, to_csv as audit_to_csv
 from .storage import (
     active_sessions_for_user,
     clear_active_session,
@@ -54,6 +58,12 @@ for sid, payload in load_all_active_sessions().items():
     }
 
 app = FastAPI(title="Skill Analyzer API")
+
+# Wire developer utilities only when explicitly enabled for staging/ops
+if os.getenv("STAGING_PROFILE", "0").lower() in {"1", "true", "yes", "on"}:
+    from . import dev as _dev  # noqa: WPS433 (intentional local import)
+
+    app.include_router(_dev.router)
 
 # api/app.py, after `app = FastAPI(...)`
 @app.get("/")
@@ -196,8 +206,77 @@ def answer(sid: str, req: AnswerReq):
     try: val = int(val)
     except Exception: pass
     sess.answer_current(Answer(item_id=req.item_id, value=val, rt_sec=(req.rt_ms/1000.0 if req.rt_ms else None)))
+    if sess.steps >= GLOBAL_STEP_CAP:
+        sess.mark_done()
+    nxt = None
+    if not sess.done:
+        nxt = sess.next_item()
+    serialized = _serialize_item(nxt) if nxt is not None else None
+    if serialized is not None:
+        NEXT_CACHE[sid] = serialized
+    else:
+        NEXT_CACHE.pop(sid, None)
+    return {"done": nxt is None, "item": serialized}
+
+
+@app.get("/session/{sid}/next")
+def next_item_endpoint(sid: str):
+    sess = SESS.get(sid)
+    if not sess:
+        raise HTTPException(404, "session not found")
+    if sess.done:
+        NEXT_CACHE.pop(sid, None)
+        return Response(status_code=204)
+    cached = NEXT_CACHE.get(sid)
+    if cached is not None:
+        return {"item": cached}
     nxt = sess.next_item()
-    return {"done": nxt is None, "item": _serialize_item(nxt)}
+    if nxt is None:
+        sess.mark_done()
+        NEXT_CACHE.pop(sid, None)
+        return Response(status_code=204)
+    serialized = _serialize_item(nxt)
+    NEXT_CACHE[sid] = serialized
+    return {"item": serialized}
+
+
+@app.post("/session/finish")
+def finish(req: FEFinish):
+    sess = SESS.get(req.session_id)
+    if not sess:
+        raise HTTPException(404, "session not found")
+    if not sess.done and sess.steps < GLOBAL_STEP_CAP:
+        return JSONResponse({"status": "continue", "steps": sess.steps}, status_code=409)
+    info = SESSION_INFO.get(req.session_id, {})
+    result = _serialize_result(sess.finalize())
+    snapshot = sess.summary()
+    summary = dict(result.get("summary") or {})
+    summary["steps_used"] = snapshot.get("steps_used", sess.steps)
+    summary["sr_used"] = snapshot.get("sr_used", 0)
+    summary["open_used"] = snapshot.get("open_used", 0)
+    summary["cap"] = f"{summary['steps_used']}/{GLOBAL_STEP_CAP}"
+    summary.setdefault("cap_limit", snapshot.get("cap_limit"))
+    result["summary"] = summary
+    report = _decorate_report(
+        result,
+        session_id=req.session_id,
+        user_id=info.get("user_id"),
+    )
+    metadata = {
+        "sessionId": req.session_id,
+        "userId": info.get("user_id"),
+        "createdAt": report["created_at"],
+        "run": info.get("run") or report.get("run_type"),
+        "kind": info.get("run") or report.get("run_type"),
+        "summary": report.get("summary"),
+    }
+    save_report(report["id"], report, metadata)
+    if info.get("user_id"):
+        clear_active_session(req.session_id)
+    NEXT_CACHE.pop(req.session_id, None)
+    SESS.pop(req.session_id, None)
+    SESSION_INFO.pop(req.session_id, None)
+    return report
 
 @app.get("/session/{sid}/report")
 def report(sid: str):
@@ -300,6 +379,66 @@ def get_report(report_id: str):
     if not report:
         raise HTTPException(404, "report not found")
     return report
+
+
+@app.post("/results/{report_id}/plan")
+def create_plan(report_id: str, force: bool = Query(False, description="Regenerate even if cached")):
+    report = load_report(report_id)
+    if not report:
+        raise HTTPException(404, "result not found")
+
+    existing = report.get("plan") if isinstance(report, dict) else None
+    if existing and not force:
+        return {"result_id": report_id, "plan": existing}
+
+    cfg = load_config()
+    plan = generate_plan(report, cfg)
+    if isinstance(report, dict):
+        report["plan"] = plan
+        meta = report.get("meta") or {}
+        metadata = {
+            "sessionId": meta.get("sessionId"),
+            "userId": meta.get("userId"),
+            "createdAt": report.get("created_at") or meta.get("createdAt"),
+            "run": meta.get("run") or meta.get("kind") or report.get("run_type"),
+            "kind": meta.get("run") or meta.get("kind") or report.get("run_type"),
+            "summary": report.get("summary"),
+        }
+        save_report(report_id, report, metadata)
+    return {"result_id": report_id, "plan": plan}
+
+
+@app.get("/results/{report_id}/audit.json")
+def get_audit_json(report_id: str):
+    if not AUDIT_EXPORT_ENABLED:
+        raise HTTPException(404, "audit export disabled")
+
+    report = load_report(report_id)
+    if not report:
+        raise HTTPException(404, "result not found")
+
+    events = report.get("audit_events") if isinstance(report, dict) else None
+    payload = audit_to_json(events or [])
+    return {"result_id": report_id, **payload}
+
+
+@app.get("/results/{report_id}/audit.csv")
+def get_audit_csv(report_id: str):
+    if not AUDIT_EXPORT_ENABLED:
+        raise HTTPException(404, "audit export disabled")
+
+    report = load_report(report_id)
+    if not report:
+        raise HTTPException(404, "result not found")
+
+    events = report.get("audit_events") if isinstance(report, dict) else None
+    body = audit_to_csv(events or [])
+    filename = f"{report_id}_audit.csv"
+    return Response(
+        content=body,
+        media_type="text/csv",
+        headers={"Content-Disposition": f"attachment; filename=\"{filename}\""},
+    )
 
 
 @app.delete("/reports/{report_id}")

--- a/api/dev.py
+++ b/api/dev.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+from typing import Any, Dict, Iterable, Optional, Sequence
+
+from fastapi import APIRouter, HTTPException, Query
+
+import skill_core.engine as engine_mod
+from skill_core.scoring import score_item
+from skill_core.types import Answer
+from skill_core import config as cfg
+import skill_core.policy as policy_mod
+from skill_core.engine import AdaptiveSession
+
+router = APIRouter()
+
+
+def _open_pass_response() -> str:
+    sentence = (
+        "Deliver evidence-based analysis with clear transitions, cite quantitative benchmarks, outline weekly review cadences, "
+        "and close with measurable decision gates to sustain 90 percent accuracy."
+    )
+    words = sentence.split()
+    payload: list[str] = []
+    while len(payload) < 150:
+        payload.extend(words)
+    return " ".join(payload[:150])
+
+
+def _candidate_indices(item: Any) -> Sequence[int]:
+    indices: set[int] = set()
+    for attr in ("options", "choices"):
+        opts = getattr(item, attr, None)
+        if isinstance(opts, Sequence) and not isinstance(opts, (str, bytes)):
+            indices.update(range(len(opts)))
+    keys = getattr(item, "keys", None) or getattr(item, "sjt_keys", None)
+    if isinstance(keys, dict):
+        for key in keys.keys():
+            try:
+                indices.add(int(key))
+            except Exception:
+                continue
+    for attr in ("correct", "best_index", "best", "key_best", "good_index", "good", "key_good"):
+        val = getattr(item, attr, None)
+        if val is None:
+            continue
+        try:
+            indices.add(int(val))
+        except Exception:
+            continue
+    if not indices:
+        indices.update(range(4))
+    return tuple(sorted(idx for idx in indices if idx >= 0))
+
+
+def _best_objective_answer(item: Any) -> str:
+    best_idx: Optional[int] = None
+    best_credit = -1.0
+    for idx in _candidate_indices(item):
+        ans = Answer(item_id=getattr(item, "id", ""), value=str(idx))
+        try:
+            credit, _ = score_item(item, ans)
+        except Exception:
+            credit = 0.0
+        if credit > best_credit:
+            best_credit = credit
+            best_idx = idx
+    return str(best_idx if best_idx is not None else 0)
+
+
+def _pass_value(item: Any) -> str:
+    item_type = str(getattr(item, "type", "")).upper()
+    if item_type in {"MCQ", "SJT"}:
+        return _best_objective_answer(item)
+    if item_type == "OPEN":
+        return _open_pass_response()
+    if item_type == "SR":
+        return "3"
+    return "1"
+
+
+def _fail_value(item: Any) -> str:
+    item_type = str(getattr(item, "type", "")).upper()
+    if item_type in {"MCQ", "SJT"}:
+        best = _best_objective_answer(item)
+        indices = list(_candidate_indices(item)) or [0]
+        try:
+            best_int = int(best)
+        except Exception:
+            best_int = 0
+        for idx in indices:
+            if idx != best_int:
+                return str(idx)
+        return str((best_int + 1) % max(len(indices), 1) if indices else 1)
+    if item_type == "SR":
+        return "0"
+    if item_type == "OPEN":
+        return "ok"
+    return "1"
+
+
+def _apply_seed(seed: Optional[int]) -> Optional[object]:
+    if seed is None:
+        return None
+    prev_state = random.getstate()
+    random.seed(int(seed))
+    return prev_state
+
+
+def simulate(run: str, mode: str, seed: Optional[int] = None) -> Dict[str, Any]:
+    run_lower = run.lower()
+    mode_lower = mode.lower()
+    if run_lower not in {"short", "long"}:
+        raise ValueError("run must be 'short' or 'long'")
+    if mode_lower not in {"pass", "fail"}:
+        raise ValueError("mode must be 'pass' or 'fail'")
+
+    prev_state = _apply_seed(seed)
+    prev_debug_seed = os.environ.get("DEBUG_SEED")
+    if seed is not None:
+        os.environ["DEBUG_SEED"] = str(seed)
+    else:
+        os.environ.pop("DEBUG_SEED", None)
+
+    try:
+        session = AdaptiveSession(run_type=run_lower)
+    finally:
+        if prev_state is not None:
+            random.setstate(prev_state)
+        if prev_debug_seed is None:
+            os.environ.pop("DEBUG_SEED", None)
+        else:
+            os.environ["DEBUG_SEED"] = prev_debug_seed
+
+    if seed is not None and hasattr(session, "policy") and hasattr(session.policy, "rng"):
+        session.policy.rng.seed(int(seed))
+
+    steps = 0
+    while not session.done:
+        item = session.next_item()
+        if item is None:
+            break
+        item_type = str(getattr(item, "type", "")).upper()
+        value = _pass_value(item) if mode_lower == "pass" else _fail_value(item)
+        rt_sec = 2.6 if item_type == "OPEN" else 2.0
+        answer = Answer(item_id=getattr(item, "id", ""), value=value, rt_sec=rt_sec)
+        session.answer_current(answer)
+        steps += 1
+
+    result = session.finalize()
+    if isinstance(result, dict):
+        summary = result.get("summary", {}) or {}
+        domain_scores = result.get("domain_scores", []) or []
+    else:
+        summary = getattr(result, "summary", {}) or {}
+        domain_scores = getattr(result, "domain_scores", []) or []
+
+    tiers: list[str] = []
+    reasons: Dict[str, list[str]] = {}
+    for score in domain_scores:
+        if isinstance(score, dict):
+            tier_val = str(score.get("tier", ""))
+            domain = str(score.get("domain", ""))
+            tier_reasons = score.get("tier_reasons")
+            if tier_reasons is None:
+                gate_meta = score.get("god_gate")
+                if isinstance(gate_meta, dict):
+                    tier_reasons = gate_meta.get("reasons")
+        else:
+            tier_val = str(getattr(score, "tier", ""))
+            domain = str(getattr(score, "domain", ""))
+            tier_reasons = getattr(score, "tier_reasons", None)
+            if tier_reasons is None:
+                gate_meta = getattr(score, "god_gate", None)
+                if isinstance(gate_meta, dict):
+                    tier_reasons = gate_meta.get("reasons")
+
+        tiers.append(tier_val)
+        if domain:
+            reasons[domain] = list(tier_reasons or [])
+
+    return {
+        "steps": int(summary.get("steps_used", steps)),
+        "cap": summary.get("cap"),
+        "sr_used": int(summary.get("sr_used", getattr(session, "sr_used", 0))),
+        "open_used": int(summary.get("open_used", getattr(session, "open_used", 0))),
+        "tiers": tiers,
+        "reasons": reasons,
+    }
+
+
+def _is_truthy(value: Optional[object]) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+@router.get("/dev/run")
+def dev_run(
+    run: str = Query("short"),
+    seed: Optional[int] = Query(None),
+    mode: str = Query("pass"),
+    test_mode_flag: Optional[str] = Query(None, alias="TEST_MODE"),
+    test_min_norm: Optional[float] = Query(None, alias="TEST_GOD_MIN_NORM"),
+    test_max_se: Optional[float] = Query(None, alias="TEST_GOD_MAX_SE"),
+    test_min_l2_seen: Optional[int] = Query(None, alias="TEST_GOD_MIN_L2_SEEN"),
+    test_min_l2_acc: Optional[float] = Query(None, alias="TEST_GOD_MIN_L2_ACC"),
+    test_min_open: Optional[int] = Query(None, alias="TEST_GOD_MIN_OPEN"),
+    test_rubric0: Optional[float] = Query(None, alias="TEST_GOD_RUBRIC0"),
+    test_rubric1: Optional[float] = Query(None, alias="TEST_GOD_RUBRIC1"),
+    test_open_full: Optional[str] = Query(None, alias="TEST_OPEN_FULL"),
+) -> Dict[str, Any]:
+    snapshots = {
+        "TEST_MODE": cfg.TEST_MODE,
+        "TEST_GOD_MIN_NORM": cfg.TEST_GOD_MIN_NORM,
+        "TEST_GOD_MAX_SE": cfg.TEST_GOD_MAX_SE,
+        "TEST_GOD_MIN_L2_SEEN": cfg.TEST_GOD_MIN_L2_SEEN,
+        "TEST_GOD_MIN_L2_ACC": cfg.TEST_GOD_MIN_L2_ACC,
+        "TEST_GOD_MIN_OPEN": cfg.TEST_GOD_MIN_OPEN,
+        "TEST_GOD_RUBRIC0": getattr(cfg, "TEST_GOD_RUBRIC0", None),
+        "TEST_GOD_RUBRIC1": getattr(cfg, "TEST_GOD_RUBRIC1", None),
+        "TEST_OPEN_FULL": getattr(cfg, "TEST_OPEN_FULL", False),
+        "OPEN_RESERVE_FORCE": getattr(cfg, "OPEN_RESERVE_FORCE", False),
+        "POLICY_TEST_MODE": getattr(policy_mod, "TEST_MODE", False),
+        "POLICY_TEST_OPEN_FULL": getattr(policy_mod, "TEST_OPEN_FULL", False),
+        "POLICY_OPEN_RESERVE_FORCE": getattr(policy_mod, "OPEN_RESERVE_FORCE", False),
+        "GOD_MIN_NORM": getattr(cfg, "GOD_MIN_NORM", 0.0),
+        "GOD_MAX_SE": getattr(cfg, "GOD_MAX_SE", 0.0),
+        "GOD_MIN_L2_SEEN": getattr(cfg, "GOD_MIN_L2_SEEN", 0),
+        "GOD_MIN_L2_ACC": getattr(cfg, "GOD_MIN_L2_ACC", 0.0),
+        "GOD_MIN_OPEN": getattr(cfg, "GOD_MIN_OPEN", 0),
+        "ENGINE_GOD_MIN_NORM": getattr(engine_mod, "GOD_MIN_NORM", 0.0),
+        "ENGINE_GOD_MAX_SE": getattr(engine_mod, "GOD_MAX_SE", 0.0),
+        "ENGINE_GOD_MIN_L2_SEEN": getattr(engine_mod, "GOD_MIN_L2_SEEN", 0),
+        "ENGINE_GOD_MIN_L2_ACC": getattr(engine_mod, "GOD_MIN_L2_ACC", 0.0),
+        "ENGINE_GOD_MIN_OPEN": getattr(engine_mod, "GOD_MIN_OPEN", 0),
+    }
+
+    try:
+        cfg.TEST_MODE = snapshots["TEST_MODE"]
+        cfg.TEST_GOD_MIN_NORM = snapshots["TEST_GOD_MIN_NORM"]
+        cfg.TEST_GOD_MAX_SE = snapshots["TEST_GOD_MAX_SE"]
+        cfg.TEST_GOD_MIN_L2_SEEN = snapshots["TEST_GOD_MIN_L2_SEEN"]
+        cfg.TEST_GOD_MIN_L2_ACC = snapshots["TEST_GOD_MIN_L2_ACC"]
+        cfg.TEST_GOD_MIN_OPEN = snapshots["TEST_GOD_MIN_OPEN"]
+        cfg.TEST_GOD_RUBRIC0 = snapshots["TEST_GOD_RUBRIC0"]
+        cfg.TEST_GOD_RUBRIC1 = snapshots["TEST_GOD_RUBRIC1"]
+        cfg.TEST_OPEN_FULL = snapshots["TEST_OPEN_FULL"]
+        cfg.OPEN_RESERVE_FORCE = snapshots["OPEN_RESERVE_FORCE"]
+        cfg.GOD_MIN_NORM = snapshots["GOD_MIN_NORM"]
+        cfg.GOD_MAX_SE = snapshots["GOD_MAX_SE"]
+        cfg.GOD_MIN_L2_SEEN = snapshots["GOD_MIN_L2_SEEN"]
+        cfg.GOD_MIN_L2_ACC = snapshots["GOD_MIN_L2_ACC"]
+        cfg.GOD_MIN_OPEN = snapshots["GOD_MIN_OPEN"]
+        engine_mod.GOD_MIN_NORM = snapshots["ENGINE_GOD_MIN_NORM"]
+        engine_mod.GOD_MAX_SE = snapshots["ENGINE_GOD_MAX_SE"]
+        engine_mod.GOD_MIN_L2_SEEN = snapshots["ENGINE_GOD_MIN_L2_SEEN"]
+        engine_mod.GOD_MIN_L2_ACC = snapshots["ENGINE_GOD_MIN_L2_ACC"]
+        engine_mod.GOD_MIN_OPEN = snapshots["ENGINE_GOD_MIN_OPEN"]
+
+        policy_mod.TEST_MODE = snapshots["POLICY_TEST_MODE"]
+        policy_mod.TEST_OPEN_FULL = snapshots["POLICY_TEST_OPEN_FULL"]
+        policy_mod.OPEN_RESERVE_FORCE = snapshots["POLICY_OPEN_RESERVE_FORCE"]
+
+        if cfg.STAGING_PROFILE and _is_truthy(test_mode_flag):
+            cfg.TEST_MODE = True
+            policy_mod.TEST_MODE = True
+            if test_min_norm is not None:
+                value = float(test_min_norm)
+                cfg.TEST_GOD_MIN_NORM = value
+                cfg.GOD_MIN_NORM = value
+                engine_mod.GOD_MIN_NORM = value
+            if test_max_se is not None:
+                value = float(test_max_se)
+                cfg.TEST_GOD_MAX_SE = value
+                cfg.GOD_MAX_SE = value
+                engine_mod.GOD_MAX_SE = value
+            if test_min_l2_seen is not None:
+                value = int(test_min_l2_seen)
+                cfg.TEST_GOD_MIN_L2_SEEN = value
+                cfg.GOD_MIN_L2_SEEN = value
+                engine_mod.GOD_MIN_L2_SEEN = value
+            if test_min_l2_acc is not None:
+                value = float(test_min_l2_acc)
+                cfg.TEST_GOD_MIN_L2_ACC = value
+                cfg.GOD_MIN_L2_ACC = value
+                engine_mod.GOD_MIN_L2_ACC = value
+            if test_min_open is not None:
+                value = int(test_min_open)
+                cfg.TEST_GOD_MIN_OPEN = value
+                cfg.GOD_MIN_OPEN = value
+                engine_mod.GOD_MIN_OPEN = value
+            if test_rubric0 is not None:
+                value = float(test_rubric0)
+                cfg.TEST_GOD_RUBRIC0 = value
+            if test_rubric1 is not None:
+                value = float(test_rubric1)
+                cfg.TEST_GOD_RUBRIC1 = value
+            if test_open_full is not None:
+                forced = _is_truthy(test_open_full)
+                cfg.TEST_OPEN_FULL = forced
+                policy_mod.TEST_OPEN_FULL = forced
+            if getattr(cfg, "TEST_OPEN_FULL", False):
+                cfg.OPEN_RESERVE_FORCE = True
+                policy_mod.OPEN_RESERVE_FORCE = True
+
+        return simulate(run, mode, seed)
+    except ValueError as exc:  # pragma: no cover - defensive guard
+        raise HTTPException(400, str(exc)) from exc
+    finally:
+        cfg.TEST_MODE = snapshots["TEST_MODE"]
+        cfg.TEST_GOD_MIN_NORM = snapshots["TEST_GOD_MIN_NORM"]
+        cfg.TEST_GOD_MAX_SE = snapshots["TEST_GOD_MAX_SE"]
+        cfg.TEST_GOD_MIN_L2_SEEN = snapshots["TEST_GOD_MIN_L2_SEEN"]
+        cfg.TEST_GOD_MIN_L2_ACC = snapshots["TEST_GOD_MIN_L2_ACC"]
+        cfg.TEST_GOD_MIN_OPEN = snapshots["TEST_GOD_MIN_OPEN"]
+        cfg.TEST_GOD_RUBRIC0 = snapshots["TEST_GOD_RUBRIC0"]
+        cfg.TEST_GOD_RUBRIC1 = snapshots["TEST_GOD_RUBRIC1"]
+        cfg.TEST_OPEN_FULL = snapshots["TEST_OPEN_FULL"]
+        cfg.OPEN_RESERVE_FORCE = snapshots["OPEN_RESERVE_FORCE"]
+        policy_mod.TEST_MODE = snapshots["POLICY_TEST_MODE"]
+        policy_mod.TEST_OPEN_FULL = snapshots["POLICY_TEST_OPEN_FULL"]
+        policy_mod.OPEN_RESERVE_FORCE = snapshots["POLICY_OPEN_RESERVE_FORCE"]
+        cfg.GOD_MIN_NORM = snapshots["GOD_MIN_NORM"]
+        cfg.GOD_MAX_SE = snapshots["GOD_MAX_SE"]
+        cfg.GOD_MIN_L2_SEEN = snapshots["GOD_MIN_L2_SEEN"]
+        cfg.GOD_MIN_L2_ACC = snapshots["GOD_MIN_L2_ACC"]
+        cfg.GOD_MIN_OPEN = snapshots["GOD_MIN_OPEN"]
+        engine_mod.GOD_MIN_NORM = snapshots["ENGINE_GOD_MIN_NORM"]
+        engine_mod.GOD_MAX_SE = snapshots["ENGINE_GOD_MAX_SE"]
+        engine_mod.GOD_MIN_L2_SEEN = snapshots["ENGINE_GOD_MIN_L2_SEEN"]
+        engine_mod.GOD_MIN_L2_ACC = snapshots["ENGINE_GOD_MIN_L2_ACC"]
+        engine_mod.GOD_MIN_OPEN = snapshots["ENGINE_GOD_MIN_OPEN"]
+
+
+def _main() -> None:
+    parser = argparse.ArgumentParser(description="Run headless adaptive simulation")
+    parser.add_argument("--run", choices=["short", "long"], default="short")
+    parser.add_argument("--mode", choices=["pass", "fail"], default="pass")
+    parser.add_argument("--seed", type=int, default=None)
+    args = parser.parse_args()
+    data = simulate(args.run, args.mode, args.seed)
+    print(json.dumps(data))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI helper
+    _main()

--- a/docs/ROLLUP.md
+++ b/docs/ROLLUP.md
@@ -1,0 +1,25 @@
+# SkillTier Adaptive Rollout Checklist
+
+## Feature Flags
+- `PLAN_ENABLED`: controls post-run improvement plan generation. Set `PLAN_ENABLED=0` to disable in staging.
+- `OPEN_ENABLED_LONG`: toggles OPEN scheduling for long adaptive runs. Use `OPEN_ENABLED_LONG=0` to keep long runs objective-only.
+- Flags honour environment overrides via `_env_bool` helpers; defaults stay conservative for production.
+
+## Caps and Objective Minima
+- Run caps default to `CAP_SHORT=48` and `CAP_LONG=160` steps. Override with environment variables if staging requires shorter passes.
+- Objective minima remain fixed at `SHORT_OBJ_MIN=3` and `OBJ_MIN_LONG=8` per domain. The engine always fulfils these before SR/OPEN and marks runs incomplete if caps are reached first.
+
+## Operational Commands
+- Bank coverage audit: `python -m skill_core.audit_bank` (writes `/tmp/bank_audit.json` and exits non-zero on warnings).
+- Smoke validation: `python -m skill_core.smoke` (set `STAGING_PROFILE=1` for a concise per-domain summary line plus cap status).
+- Plan endpoint smoke: `uvicorn api.app:app --reload` then `curl -X POST http://localhost:8000/results/<id>/plan` (use `PLAN_ENABLED=0` to verify disablement).
+
+## Staging Environment Example
+```
+export PLAN_ENABLED=1
+export OPEN_ENABLED_LONG=1
+export CAP_LONG=140
+export STAGING_PROFILE=1
+python -m skill_core.audit_bank
+python -m skill_core.smoke
+```

--- a/skill_core/audit_bank.py
+++ b/skill_core/audit_bank.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import json
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+from . import config
+from .question_bank import DOMAINS, load_bank
+from .types import Item
+
+OBJ_BUCKETS: tuple[int, ...] = (-2, -1, 0, 1, 2)
+OPEN_BUCKETS: tuple[int, ...] = (-1, 0, 1)
+
+
+def _blank_domain() -> dict[str, object]:
+    return {
+        "MCQ": {lvl: 0 for lvl in OBJ_BUCKETS},
+        "SJT": {lvl: 0 for lvl in OBJ_BUCKETS},
+        "OPEN": {lvl: 0 for lvl in OPEN_BUCKETS},
+        "missing_variant_group": 0,
+    }
+
+
+def audit_items(
+    items: Iterable[Item],
+    *,
+    min_obj: int | None = None,
+    min_open: int | None = None,
+    require_variant_group: bool | None = None,
+) -> dict[str, object]:
+    coverage: dict[str, dict[str, object]] = {domain: _blank_domain() for domain in DOMAINS}
+    totals = {"MCQ": 0, "SJT": 0, "OPEN": 0, "missing_variant_group": 0}
+
+    min_obj = config.BANK_MIN_PER_BUCKET_OBJ if min_obj is None else int(min_obj)
+    min_open = config.BANK_MIN_PER_BUCKET_OPEN if min_open is None else int(min_open)
+    require_variant_group = (
+        config.BANK_EXPECT_VARIANT_GROUP
+        if require_variant_group is None
+        else bool(require_variant_group)
+    )
+
+    for item in items:
+        domain_data = coverage.setdefault(item.domain, _blank_domain())
+
+        if not getattr(item, "variant_group", None):
+            domain_data["missing_variant_group"] += 1
+            totals["missing_variant_group"] += 1
+
+        bucket_map: dict[int, int] | None = None
+        if item.type in ("MCQ", "SJT"):
+            bucket_map = domain_data[item.type]  # type: ignore[index]
+            totals[item.type] += 1
+        elif item.type == "OPEN":
+            bucket_map = domain_data[item.type]  # type: ignore[index]
+            totals["OPEN"] += 1
+
+        if bucket_map is not None and isinstance(item.difficulty, int):
+            if item.difficulty not in bucket_map:
+                bucket_map[item.difficulty] = 0
+            bucket_map[item.difficulty] += 1
+
+    warnings: list[str] = []
+    for domain, data in coverage.items():
+        mcq = data["MCQ"]  # type: ignore[assignment]
+        sjt = data["SJT"]  # type: ignore[assignment]
+        open_map = data["OPEN"]  # type: ignore[assignment]
+
+        for lvl in OBJ_BUCKETS:
+            if mcq.get(lvl, 0) < min_obj:
+                warnings.append(
+                    f"{domain} MCQ level {lvl:+d} has {mcq.get(lvl, 0)} (<{min_obj})"
+                )
+            if sjt.get(lvl, 0) < min_obj:
+                warnings.append(
+                    f"{domain} SJT level {lvl:+d} has {sjt.get(lvl, 0)} (<{min_obj})"
+                )
+
+        for lvl in OPEN_BUCKETS:
+            if open_map.get(lvl, 0) < min_open:
+                warnings.append(
+                    f"{domain} OPEN level {lvl:+d} has {open_map.get(lvl, 0)} (<{min_open})"
+                )
+
+        missing_vg = data["missing_variant_group"]  # type: ignore[assignment]
+        if missing_vg and require_variant_group:
+            warnings.append(f"{domain} has {missing_vg} items missing variant_group")
+
+    summary = {"coverage": coverage, "warnings": warnings, "totals": totals}
+    return summary
+
+
+def _format_row(label: str, buckets: Iterable[int], data: dict[int, int]) -> str:
+    parts = [label]
+    for lvl in buckets:
+        parts.append(f"{lvl:+d}:{data.get(lvl, 0):3d}")
+    return "  ".join(parts)
+
+
+def print_report(summary: dict[str, object]) -> None:
+    coverage: dict[str, dict[str, object]] = summary["coverage"]  # type: ignore[assignment]
+    print("=== Bank Coverage ===")
+    for domain in sorted(coverage):
+        data = coverage[domain]
+        print(f"\nDomain: {domain}")
+        print("  " + _format_row("MCQ ", OBJ_BUCKETS, data["MCQ"]))  # type: ignore[arg-type]
+        print("  " + _format_row("SJT ", OBJ_BUCKETS, data["SJT"]))  # type: ignore[arg-type]
+        print("  " + _format_row("OPEN", OPEN_BUCKETS, data["OPEN"]))  # type: ignore[arg-type]
+        missing_vg = data["missing_variant_group"]  # type: ignore[index]
+        if missing_vg:
+            print(f"    missing_variant_group: {missing_vg}")
+
+    warnings: list[str] = summary["warnings"]  # type: ignore[assignment]
+    if warnings:
+        print("\nWarnings:")
+        for msg in warnings:
+            print(f" - {msg}")
+    else:
+        print("\nNo warnings.")
+
+    totals = summary["totals"]
+    print("\nTotals:", totals)
+
+
+def write_summary(summary: dict[str, object], path: Path = Path("/tmp/bank_audit.json")) -> str:
+    text = json.dumps(summary, indent=2, sort_keys=True)
+    path.write_text(text + "\n", encoding="utf-8")
+    print(text)
+    return text
+
+
+def main(_argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Audit bank coverage for adaptive ladder readiness")
+    parser.add_argument("--allow-warn", dest="allow_warn", action="store_true", help="exit with status 0 even when warnings are present")
+    parser.add_argument("--min-obj", type=int, default=None, help="override minimum MCQ/SJT items per difficulty bucket")
+    parser.add_argument("--min-open", type=int, default=None, help="override minimum OPEN items per difficulty bucket")
+    parser.add_argument("--no-vg-required", action="store_true", help="suppress missing variant_group warnings")
+    args = parser.parse_args(_argv)
+
+    items = load_bank()
+    summary = audit_items(
+        items,
+        min_obj=args.min_obj,
+        min_open=args.min_open,
+        require_variant_group=False if args.no_vg_required else None,
+    )
+    print_report(summary)
+    write_summary(summary)
+    allow_warn = args.allow_warn or config.BANK_AUDIT_ALLOW_WARN
+    exit_code = 0 if (allow_warn or not summary["warnings"]) else 2
+    print(
+        f"AUDIT: exit={exit_code} warnings={len(summary['warnings'])} allow_warn={bool(allow_warn)}"
+    )
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skill_core/audit_export.py
+++ b/skill_core/audit_export.py
@@ -1,0 +1,62 @@
+"""Helpers to export per-step audit traces in JSON/CSV formats."""
+from __future__ import annotations
+
+from typing import Iterable, List, Dict, Any
+import csv
+import io
+
+_FIELDS: tuple[str, ...] = (
+    "t",
+    "domain",
+    "item_id",
+    "type",
+    "b",
+    "level_before",
+    "level_after",
+    "correct_or_r",
+    "theta_before",
+    "theta_after",
+    "se_after",
+    "latency_ms",
+)
+
+
+def _normalize_event(event: Dict[str, Any]) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    for key in _FIELDS:
+        val = event.get(key)
+        if key in {"b", "level_before", "level_after", "latency_ms"}:
+            try:
+                out[key] = int(val)
+            except (TypeError, ValueError):
+                out[key] = 0
+        elif key in {"correct_or_r", "theta_before", "theta_after", "se_after"}:
+            try:
+                out[key] = float(val)
+            except (TypeError, ValueError):
+                out[key] = 0.0
+        else:
+            out[key] = "" if val is None else str(val)
+    return out
+
+
+def to_json(events: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return a JSON-safe payload for audit export."""
+
+    normalized: List[Dict[str, Any]] = [_normalize_event(evt or {}) for evt in events]
+    return {"events": normalized}
+
+
+def to_csv(events: Iterable[Dict[str, Any]]) -> str:
+    """Render audit events as CSV with a fixed header."""
+
+    normalized = [_normalize_event(evt or {}) for evt in events]
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=_FIELDS)
+    writer.writeheader()
+    for row in normalized:
+        writer.writerow(row)
+    return buf.getvalue()
+
+
+__all__ = ["to_json", "to_csv"]

--- a/skill_core/config.py
+++ b/skill_core/config.py
@@ -1,6 +1,253 @@
-
 from __future__ import annotations
+import math
 import os, json, pathlib, random
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw.strip())
+    except ValueError:
+        return default
+
+
+def _env_float(name: str, default: float | None) -> float | None:
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return float(raw.strip())
+    except ValueError:
+        return default
+
+
+RASCH_PRIOR_VAR: float = 1.0
+RASCH_ETA: float = 1.0
+MIN_LEVEL: int = -2
+MAX_LEVEL: int = 2
+
+CAP_SHORT: int = 48
+CAP_LONG: int = 160
+
+SHORT_PASS: dict[str, int] = {"need": 2, "window": 3}
+PASS_RULE_SHORT = SHORT_PASS
+PASS_RULE_LONG  = {"need": 3, "window": 4}
+SHORT_DEMOTE: dict[str, int] = {"need": 2, "window": 3}
+DEMOTE_RULE     = {"need": 2, "window": 3}
+
+TIER_NAMES: tuple[str, ...] = ("F", "D", "C", "B", "A", "S", "SS", "GOD")
+SHORT_TIER_CAP: str = "A"
+GOD_MIN_NORM: float = 9.85
+GOD_MAX_SE: float = 0.20
+GOD_REQ_LEVEL: int = 2
+GOD_MIN_L2_SEEN_DEFAULT: int = 4
+GOD_MIN_L2_SEEN: int = GOD_MIN_L2_SEEN_DEFAULT
+GOD_MIN_L2_ACC: float = 0.80
+GOD_MIN_OPEN_DEFAULT: int = 2
+GOD_MIN_OPEN: int = GOD_MIN_OPEN_DEFAULT
+GOD_MIN_R1: float = 0.80
+GOD_MIN_R2: float = 0.75
+
+SE_TARGET_SHORT: float = 0.35
+SE_TARGET_LONG: float = 0.25
+
+SHORT_OBJ_MIN: int = 3
+SHORT_OBJ_MAX: int = 5
+SHORT_EXTRA_TOTAL: int = 8  # +2 objectives for four domains
+SHORT_SR_PER_DOMAIN: int = 1
+SHORT_LEVELS: tuple[int, int, int] = (-1, 0, 1)
+SHORT_START_LEVEL: int = 0
+OBJ_MIN_SHORT: int = SHORT_OBJ_MIN
+OBJ_MAX_SHORT: int = SHORT_OBJ_MAX
+OBJ_MIN_LONG: int = 8
+OBJ_MAX_LONG: int = 16
+
+LEVEL_MIN: int = -2
+LEVEL_MAX: int = 2
+
+GLOBAL_STEP_CAP: int = CAP_LONG
+
+OPEN_ENABLED_LONG: bool = True
+OPEN_GATE1_MIN_OBJ: int = 4
+OPEN_GATE1_SE_MAX: float = 0.60
+OPEN_GATE2_SE_MAX: float = 0.45
+OPEN_GATE2_MIN_R1: float = 0.60
+OPEN_LEVELS: tuple[int, int, int] = (-1, 0, 1)
+A_OPEN: float = 0.50
+ETA_OPEN: float = 0.10
+DELTA_OPEN_MAX: float = 0.30
+OPEN_INFO_CAP_RATIO: float = 0.20
+OPEN_MIN_WORDS: int = 80
+OPEN_MIN_RUBRIC: float = 0.60
+OPEN_LATENCY_P10_MS: int = 1500
+OPEN_Z_SHIFT: float = 0.50
+OPEN_FALLBACK_AFTER_OBJ: int = 12
+OPEN_FALLBACK_MIN_STABLE: int = 1
+OPEN_DEBUG_REASON: bool = True
+
+SR_PER_DOMAIN_SHORT: int = SHORT_SR_PER_DOMAIN
+SR_PER_DOMAIN_LONG: int = 2
+SR_START_SHIFT: dict[str, int] = {"low": -1, "mid": 0, "high": 1}
+
+BANK_MIN_PER_BUCKET_OBJ: int = 20
+BANK_MIN_PER_BUCKET_OPEN: int = 10
+BANK_EXPECT_VARIANT_GROUP: bool = True
+BANK_AUDIT_ALLOW_WARN: bool = False
+
+AUDIT_EXPORT_ENABLED: bool = True
+
+PLAN_ENABLED: bool = True
+PLAN_LONG_ONLY: bool = True
+PLAN_FOCUS_MAX: int = 3
+PLAN_BULLETS_MIN: int = 3
+PLAN_BULLETS_MAX: int = 5
+PLAN_MIN_ITEMS_LONG: int = 90
+PLAN_SE_TARGET_LONG: float = SE_TARGET_LONG
+PLAN_LLM_ENABLED: bool = False
+PLAN_LATENCY_BUCKETS: tuple[float, float] = (0.25, 0.75)
+
+DEBUG_TRACE: bool = False
+DEBUG_SEED: int | None = None
+STAGING_PROFILE: bool = False
+TEST_MODE: bool = False
+TEST_OPEN_FULL: bool = False
+TEST_GOD_MAX_SE: float | None = None
+TEST_GOD_MIN_NORM: float | None = None
+TEST_GOD_MIN_L2_SEEN: int | None = None
+TEST_GOD_MIN_L2_ACC: float | None = None
+TEST_GOD_MIN_OPEN: int | None = None
+TEST_GOD_RUBRIC0: float | None = None
+TEST_GOD_RUBRIC1: float | None = None
+OPEN_RESERVE_FORCE: bool = False
+TRACE_FIELDS: tuple[str, ...] = (
+    "domain",
+    "item_id",
+    "type",
+    "level",
+    "b",
+    "correct_or_r",
+    "theta_before",
+    "theta_after",
+    "se",
+    "info_gain",
+)
+# // env overrides for staging/ops; defaults remain conservative.
+PLAN_ENABLED = _env_bool("PLAN_ENABLED", PLAN_ENABLED)
+OPEN_ENABLED_LONG = _env_bool("OPEN_ENABLED_LONG", OPEN_ENABLED_LONG)
+CAP_SHORT = _env_int("CAP_SHORT", CAP_SHORT)
+CAP_LONG = _env_int("CAP_LONG", CAP_LONG)
+DEBUG_TRACE = _env_bool("DEBUG_TRACE", False)
+DEBUG_SEED = os.getenv("DEBUG_SEED", None)
+STAGING_PROFILE = _env_bool("STAGING_PROFILE", False)
+TEST_MODE = _env_bool("TEST_MODE", TEST_MODE)
+TEST_OPEN_FULL = _env_bool("TEST_OPEN_FULL", TEST_OPEN_FULL)
+TEST_GOD_MAX_SE = _env_float("TEST_GOD_MAX_SE", TEST_GOD_MAX_SE)
+TEST_GOD_MIN_NORM = _env_float("TEST_GOD_MIN_NORM", TEST_GOD_MIN_NORM)
+TEST_GOD_MIN_L2_SEEN = _env_int("TEST_GOD_MIN_L2_SEEN", TEST_GOD_MIN_L2_SEEN or 0)
+TEST_GOD_MIN_L2_ACC = _env_float("TEST_GOD_MIN_L2_ACC", TEST_GOD_MIN_L2_ACC)
+TEST_GOD_MIN_OPEN = _env_int("TEST_GOD_MIN_OPEN", TEST_GOD_MIN_OPEN or 0)
+TEST_GOD_RUBRIC0 = _env_float("TEST_GOD_RUBRIC0", TEST_GOD_RUBRIC0)
+TEST_GOD_RUBRIC1 = _env_float("TEST_GOD_RUBRIC1", TEST_GOD_RUBRIC1)
+if TEST_GOD_MIN_L2_SEEN == 0 and TEST_GOD_MIN_L2_SEEN is not None:
+    TEST_GOD_MIN_L2_SEEN = None
+if TEST_GOD_MIN_OPEN == 0 and TEST_GOD_MIN_OPEN is not None:
+    TEST_GOD_MIN_OPEN = None
+AUDIT_EXPORT_ENABLED = _env_bool("AUDIT_EXPORT_ENABLED", AUDIT_EXPORT_ENABLED)
+BANK_AUDIT_ALLOW_WARN = _env_bool("BANK_AUDIT_ALLOW_WARN", BANK_AUDIT_ALLOW_WARN)
+
+if STAGING_PROFILE and TEST_MODE and TEST_OPEN_FULL:
+    OPEN_RESERVE_FORCE = True
+
+
+def god_thresholds(cfg: object | None = None) -> dict[str, float | int]:
+    """Return the effective GOD gate thresholds with staging overrides."""
+
+    module = cfg if cfg is not None else globals()
+
+    def _value(name: str):
+        return module[name] if isinstance(module, dict) else getattr(module, name)
+
+    thresholds = {
+        "min_norm": float(_value("GOD_MIN_NORM")),
+        "max_se": float(_value("GOD_MAX_SE")),
+        "min_l2_seen": int(_value("GOD_MIN_L2_SEEN")),
+        "min_l2_acc": float(_value("GOD_MIN_L2_ACC")),
+        "min_open": int(_value("GOD_MIN_OPEN")),
+        "rubric0": float(_value("GOD_MIN_R1")),
+        "rubric1": float(_value("GOD_MIN_R2")),
+    }
+
+    staging = bool(_value("STAGING_PROFILE"))
+    test_mode = bool(_value("TEST_MODE"))
+
+    if staging and test_mode:
+        min_norm = _value("TEST_GOD_MIN_NORM")
+        max_se = _value("TEST_GOD_MAX_SE")
+        min_l2_seen = _value("TEST_GOD_MIN_L2_SEEN")
+        min_l2_acc = _value("TEST_GOD_MIN_L2_ACC")
+        min_open = _value("TEST_GOD_MIN_OPEN")
+        rubric0 = _value("TEST_GOD_RUBRIC0")
+        rubric1 = _value("TEST_GOD_RUBRIC1")
+
+        if min_norm is not None:
+            thresholds["min_norm"] = float(min_norm)
+        if max_se is not None:
+            thresholds["max_se"] = float(max_se)
+        if min_l2_seen is not None:
+            thresholds["min_l2_seen"] = int(min_l2_seen)
+        if min_l2_acc is not None:
+            thresholds["min_l2_acc"] = float(min_l2_acc)
+        if min_open is not None:
+            thresholds["min_open"] = int(min_open)
+        if rubric0 is not None:
+            thresholds["rubric0"] = float(rubric0)
+        if rubric1 is not None:
+            thresholds["rubric1"] = float(rubric1)
+
+        test_min_open = min_open
+        test_min_l2_seen = min_l2_seen
+    else:
+        test_min_open = None
+        test_min_l2_seen = None
+
+    if staging and test_mode:
+        min_open_val = thresholds["min_open"]
+        if test_min_open is not None and min_open_val > 0:
+            try:
+                from .question_bank import DOMAINS as _DOMAINS  # type: ignore import-not-found
+                domain_count = max(1, len(_DOMAINS))
+            except Exception:  # pragma: no cover - defensive guard
+                domain_count = 1
+            if test_min_open > GOD_MIN_OPEN_DEFAULT and test_min_open >= domain_count:
+                thresholds["min_open"] = max(
+                    1,
+                    int(math.ceil(float(test_min_open) / float(domain_count))),
+                )
+
+        min_l2_seen_val = thresholds["min_l2_seen"]
+        if test_min_l2_seen is not None and min_l2_seen_val > 0:
+            try:
+                from .question_bank import DOMAINS as _DOMAINS  # type: ignore import-not-found
+                domain_count = max(1, len(_DOMAINS))
+            except Exception:  # pragma: no cover - defensive guard
+                domain_count = 1
+            if test_min_l2_seen > GOD_MIN_L2_SEEN_DEFAULT and test_min_l2_seen >= domain_count:
+                thresholds["min_l2_seen"] = max(
+                    1,
+                    int(math.ceil(float(test_min_l2_seen) / float(domain_count))),
+                )
+
+    return thresholds
+
 def _env_true(name: str) -> bool:
     return os.environ.get(name, "").lower() in ("1","true","yes","on")
 def load_config() -> dict:

--- a/skill_core/engine.py
+++ b/skill_core/engine.py
@@ -2,20 +2,528 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
-import math, random, os, json, csv, time
+from types import SimpleNamespace
+from datetime import datetime, timezone
+import random, os, json, csv, time, logging, re, math
+from pathlib import Path
 
 from .types import Item, Answer, DomainScore, HiddenSkill, Result
 from .question_bank import load_bank, DOMAINS
 from .scoring import score_item
 from .validators import count_traps, consistency_index
-from .rarity import tier, rarity_label
-from .config import load_config, seed_rng
+from .rarity import rarity_label
+from .config import (
+    load_config,
+    seed_rng,
+    RASCH_PRIOR_VAR,
+    RASCH_ETA,
+    SHORT_PASS,
+    PASS_RULE_LONG,
+    SHORT_DEMOTE,
+    DEMOTE_RULE,
+    SE_TARGET_SHORT,
+    SE_TARGET_LONG,
+    SHORT_OBJ_MIN,
+    SHORT_OBJ_MAX,
+    OBJ_MIN_SHORT,
+    OBJ_MAX_SHORT,
+    OBJ_MIN_LONG,
+    OBJ_MAX_LONG,
+    CAP_SHORT,
+    CAP_LONG,
+    LEVEL_MIN,
+    LEVEL_MAX,
+    SHORT_LEVELS,
+    SHORT_START_LEVEL,
+    A_OPEN,
+    ETA_OPEN,
+    DELTA_OPEN_MAX,
+    OPEN_INFO_CAP_RATIO,
+    OPEN_MIN_WORDS,
+    OPEN_MIN_RUBRIC,
+    OPEN_LATENCY_P10_MS,
+    SR_START_SHIFT,
+    TIER_NAMES,
+    SHORT_TIER_CAP,
+    GOD_MIN_NORM,
+    GOD_MAX_SE,
+    GOD_REQ_LEVEL,
+    GOD_MIN_L2_SEEN,
+    GOD_MIN_L2_ACC,
+    GOD_MIN_OPEN,
+    GLOBAL_STEP_CAP,
+    DEBUG_TRACE,
+    TRACE_FIELDS,
+    god_thresholds,
+)
 from .policy import QuestionPolicy, PolicyState, DomainHistory
+from . import rasch
 
-# Composite base weights for domain scores
-W_OPEN_BASE = 0.60
-W_OBJ       = 0.35
-W_SR        = 0.05
+
+log = logging.getLogger(__name__)
+
+
+def _emit_trace(**values: object) -> None:
+    if not DEBUG_TRACE:
+        return
+    ordered = []
+    for key in TRACE_FIELDS:
+        if key in values:
+            ordered.append(f"{key}={values[key]}")
+    if ordered:
+        log.info("trace %s", " ".join(str(val) for val in ordered))
+
+
+def _default_level_stats() -> Dict[int, Dict[str, int]]:
+    return {lvl: {"seen": 0, "correct": 0} for lvl in range(-2, 3)}
+
+
+_RECENT_WINDOW_LIMIT = max(
+    SHORT_PASS["window"],
+    PASS_RULE_LONG["window"],
+    SHORT_DEMOTE["window"],
+    DEMOTE_RULE["window"],
+)
+
+
+def _clamp_level(level: int) -> int:
+    return max(LEVEL_MIN, min(LEVEL_MAX, int(level)))
+
+
+_CALIBRATION_V2_CACHE: Optional[Dict[str, object]] = None
+
+
+def _load_calibration_v2() -> Dict[str, object]:
+    """Lazy-load calibration metadata used to map θ to normed scores."""
+
+    global _CALIBRATION_V2_CACHE
+    if _CALIBRATION_V2_CACHE is None:
+        path = Path(__file__).with_name("calibration_v2.json")
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                _CALIBRATION_V2_CACHE = json.load(f)
+        except Exception:
+            _CALIBRATION_V2_CACHE = {
+                "floor": 10.0,
+                "ceil": 100.0,
+                "min_span": 40.0,
+                "domains": {},
+            }
+    return _CALIBRATION_V2_CACHE
+
+
+def _theta_to_norm_score(theta: float, domain: str) -> float:
+    """Convert Rasch θ into the calibrated 0–100 domain score."""
+
+    calib = _load_calibration_v2()
+    base_prob = rasch.sigma(theta)
+    base_scale = base_prob * 10.0  # 0..10 ability anchor
+
+    floor = float(calib.get("floor", 10.0))
+    ceil = float(calib.get("ceil", 100.0))
+    min_span = float(calib.get("min_span", 40.0))
+    domain_cfg = calib.get("domains", {}).get(domain, {})
+    worst = float(domain_cfg.get("worst", floor))
+    best = float(domain_cfg.get("best", ceil))
+
+    if best <= worst:
+        best = worst + min_span
+
+    span = max(best - worst, min_span)
+    span = min(span, max(ceil - floor, min_span))
+
+    score = worst + (base_scale / 10.0) * span
+    return float(max(floor, min(ceil, score)))
+
+
+_BASE_TIER_THRESHOLDS: tuple[tuple[float, str], ...] = (
+    (9.6, "SS"),
+    (9.0, "S"),
+    (7.5, "A"),
+    (6.0, "B"),
+    (4.5, "C"),
+    (3.0, "D"),
+)
+
+
+def _base_tier_from_norm(norm: float) -> str:
+    value = float(norm)
+    for cutoff, label in _BASE_TIER_THRESHOLDS:
+        if value >= cutoff:
+            return label
+    return "F"
+
+
+def _lookup_level_metric(data: Dict[int | str, float], level: int, default: float) -> float:
+    if not isinstance(data, dict):
+        return float(default)
+    if level in data:
+        try:
+            return float(data[level])
+        except Exception:
+            return float(default)
+    key = str(level)
+    if key in data:
+        try:
+            return float(data[key])
+        except Exception:
+            return float(default)
+    return float(default)
+
+
+def map_tier(norm: float, run_type: str, dstate: object) -> str:
+    """Map calibrated norm to tier label with short caps and GOD gating."""
+
+    meta = {"short_cap": False}
+    norm_val = float(norm)
+
+    items_by_level = getattr(dstate, "items_by_level", {}) or {}
+    accuracy_by_level = getattr(dstate, "accuracy_by_level", {}) or {}
+    open_ratings_raw = getattr(dstate, "open_ratings", []) or []
+    open_ratings: List[float] = []
+    for raw in open_ratings_raw:
+        try:
+            open_ratings.append(float(raw))
+        except Exception:
+            continue
+
+    if run_type == "long":
+        thresholds = god_thresholds()
+        se_val = float(getattr(dstate, "se", 1.0))
+        b_stable = int(getattr(dstate, "b_stable", 0))
+        open_count = int(getattr(dstate, "open_count", 0))
+        l2_seen = int(_lookup_level_metric(items_by_level, 2, 0))
+        l2_acc = float(_lookup_level_metric(accuracy_by_level, 2, 0.0))
+
+        norm_ok = norm_val >= thresholds["min_norm"]
+        level_ok = b_stable >= GOD_REQ_LEVEL
+        se_ok = se_val <= thresholds["max_se"]
+        l2_seen_ok = l2_seen >= thresholds["min_l2_seen"]
+        l2_acc_ok = l2_acc >= thresholds["min_l2_acc"]
+        open_requirement = max(int(thresholds["min_open"]), 0)
+        rubric0 = float(thresholds["rubric0"])
+        rubric1 = float(thresholds["rubric1"])
+
+        reasons: List[str] = []
+        gate_checks = [
+            (norm_ok, "norm_low"),
+            (level_ok, "not_stable_l2"),
+            (se_ok, "se_high"),
+            (l2_seen_ok, "l2_seen_low"),
+            (l2_acc_ok, "l2_acc_low"),
+        ]
+
+        ok = True
+        for passed, label in gate_checks:
+            if not passed:
+                ok = False
+                reasons.append(label)
+
+        open_count_ok = True
+        open_rubric_ok = True
+        if open_requirement > 0:
+            open_count_ok = open_count >= open_requirement
+            if not open_count_ok:
+                ok = False
+                reasons.append("open_count_low")
+            else:
+                if len(open_ratings) >= 2:
+                    open_rubric_ok = (
+                        open_ratings[0] >= rubric0 and open_ratings[1] >= rubric1
+                    )
+                else:
+                    open_rubric_ok = False
+                if not open_rubric_ok:
+                    ok = False
+                    reasons.append("open_rubric_low")
+
+        gate_info = {
+            "status": "none",
+            "norm_ok": norm_ok,
+            "level_ok": level_ok,
+            "se_ok": se_ok,
+            "l2_seen_ok": l2_seen_ok,
+            "l2_acc_ok": l2_acc_ok,
+            "open_count_ok": open_count_ok,
+            "open_rubric_ok": open_rubric_ok,
+            "min_open": open_requirement,
+            "reasons": reasons,
+        }
+
+        if ok:
+            gate_info["status"] = "pass"
+            gate_info["reasons"] = reasons
+            meta["god_gate"] = gate_info
+            setattr(dstate, "_tier_meta", meta)
+            return "GOD"
+
+        if norm_ok:
+            gate_info["status"] = "near"
+
+        gate_info["reasons"] = reasons
+        meta["god_gate"] = gate_info
+    else:
+        meta["god_gate"] = {"status": "na"}
+
+    base_label = _base_tier_from_norm(norm_val)
+    meta["base_tier"] = base_label
+    final_label = base_label
+
+    if run_type == "short":
+        try:
+            cap_idx = TIER_NAMES.index(SHORT_TIER_CAP)
+            base_idx = TIER_NAMES.index(base_label)
+        except ValueError:
+            cap_idx = TIER_NAMES.index(SHORT_TIER_CAP)
+            base_idx = cap_idx
+        if base_idx > cap_idx:
+            final_label = SHORT_TIER_CAP
+            meta["short_cap"] = True
+        else:
+            meta["short_cap"] = False
+    else:
+        meta.setdefault("short_cap", False)
+
+    setattr(dstate, "_tier_meta", meta)
+    return final_label
+
+def _sr_shift_from_mean(mean: Optional[float]) -> int:
+    if mean is None:
+        return 0
+    if mean <= 2.5:
+        return int(SR_START_SHIFT.get("low", -1))
+    if mean >= 4.5:
+        return int(SR_START_SHIFT.get("high", 1))
+    return int(SR_START_SHIFT.get("mid", 0))
+
+
+def _is_negative_sr_item(item: Item) -> bool:
+    pol = getattr(item, "polarity", None)
+    if isinstance(pol, str) and pol.lower().startswith("neg"):
+        return True
+    iid = getattr(item, "id", None)
+    return isinstance(iid, str) and iid.endswith("_neg")
+
+
+def _sr_normalized_value(item: Item, answer: Answer) -> Optional[int]:
+    try:
+        raw = int(getattr(answer, "value", 0))
+    except Exception:
+        return None
+    if raw < 0:
+        raw = 0
+    if raw > 4:
+        raw = 4
+    likert = raw + 1
+    if _is_negative_sr_item(item):
+        likert = 6 - likert
+    return likert
+
+
+def _sr_trap_failed(item: Item, answer: Answer) -> bool:
+    if not getattr(item, "is_trap", False):
+        return False
+    try:
+        val = int(getattr(answer, "value", 0))
+    except Exception:
+        return False
+    flag = getattr(item, "trap_flag_index", None)
+    if flag is not None:
+        try:
+            return int(val) == int(flag)
+        except Exception:
+            return False
+    return int(val) == 5
+
+
+def _run_parameters(run_type: str) -> tuple[dict, float, int, int]:
+    if run_type == "short":
+        return SHORT_PASS, SE_TARGET_SHORT, SHORT_OBJ_MIN, SHORT_OBJ_MAX
+    return PASS_RULE_LONG, SE_TARGET_LONG, OBJ_MIN_LONG, OBJ_MAX_LONG
+
+
+def _apply_objective_step(
+    domain_state: DomainState,
+    level_bucket: int,
+    correct: bool,
+    run_type: str,
+    target_level: Optional[int] = None,
+) -> Dict[str, object]:
+    """Apply Rasch update and ladder progression for an objective answer."""
+
+    short_run = run_type == "short"
+    if short_run:
+        short_min = min(SHORT_LEVELS)
+        short_max = max(SHORT_LEVELS)
+
+        def clamp(val: int) -> int:
+            return max(short_min, min(short_max, int(val)))
+    else:
+
+        def clamp(val: int) -> int:
+            return _clamp_level(val)
+
+    prev_level_raw = int(domain_state.level)
+    prev_level = clamp(prev_level_raw)
+    if prev_level != prev_level_raw:
+        domain_state.level = prev_level
+
+    bucket = clamp(level_bucket)
+
+    theta_before = domain_state.theta
+    theta_after = rasch.map_update(
+        theta_before,
+        bucket,
+        bool(correct),
+        a=1.0,
+        prior_var=RASCH_PRIOR_VAR,
+        eta=RASCH_ETA,
+    )
+    info_delta = rasch.item_info(theta_after, bucket, a=1.0)
+
+    domain_state.theta = theta_after
+    domain_state.info_total = max(domain_state.info_total + info_delta, 1e-6)
+    domain_state.obj_info_total = max(domain_state.obj_info_total + info_delta, 0.0)
+    domain_state.se = rasch.se_from_info(domain_state.info_total + domain_state.open_info_total)
+    domain_state.obj_count += 1
+
+    stats = domain_state.level_stats.setdefault(bucket, {"seen": 0, "correct": 0})
+    stats["seen"] += 1
+    stats["correct"] += int(correct)
+
+    window_level_raw = prev_level if target_level is None else int(target_level)
+    window_level = clamp(window_level_raw)
+    same_level = window_level == prev_level
+    if same_level:
+        domain_state.recent_window.append(bool(correct))
+        if len(domain_state.recent_window) > _RECENT_WINDOW_LIMIT:
+            domain_state.recent_window.pop(0)
+        domain_state.level_entry_seen += 1
+    else:
+        domain_state.recent_window = [bool(correct)]
+        domain_state.level_entry_seen = 1
+
+    pass_rule, _, _, _ = _run_parameters(run_type)
+    demote_rule = SHORT_DEMOTE if short_run else DEMOTE_RULE
+    new_level = prev_level
+    promoted = False
+    if same_level:
+        window = domain_state.recent_window[-pass_rule["window"] :]
+        if len(window) >= pass_rule["window"] and sum(window) >= pass_rule["need"]:
+            new_level = clamp(prev_level + 1)
+            domain_state.b_stable = max(domain_state.b_stable, prev_level)
+            domain_state.recent_window = []
+            domain_state.level_entry_seen = 0
+            promoted = True
+
+    if same_level and not promoted:
+        demo_window = domain_state.recent_window[-demote_rule["window"] :]
+        if len(demo_window) >= demote_rule["window"]:
+            misses = demote_rule["window"] - sum(demo_window)
+            if misses >= demote_rule["need"] and domain_state.level_entry_seen > 1:
+                new_level = clamp(prev_level - 1)
+                domain_state.recent_window = []
+                domain_state.level_entry_seen = 0
+
+    domain_state.level = clamp(new_level)
+    if domain_state.obj_count == 1:
+        domain_state.b_peak = new_level
+    else:
+        domain_state.b_peak = max(domain_state.b_peak, new_level)
+
+    return {
+        "theta_before": theta_before,
+        "theta_after": theta_after,
+        "info_delta": info_delta,
+        "level_before": prev_level,
+        "level_after": new_level,
+        "window": list(domain_state.recent_window),
+        "stats": dict(stats),
+        "se": domain_state.se,
+    }
+
+
+def _apply_open_step(
+    domain_state: DomainState,
+    difficulty: int,
+    score: float,
+    word_count: int,
+    latency_ms: float,
+    rubric_conf: Optional[float],
+) -> Dict[str, object]:
+    """Apply bounded Rasch-style residual update for an OPEN response."""
+
+    bucket = max(min(int(difficulty), 1), -1)
+    theta_before = domain_state.theta
+    mu = rasch.sigma(theta_before - bucket)
+
+    eta = ETA_OPEN
+    eta_halved = False
+    ignored_reason: Optional[str] = None
+    scaled = False
+    dtheta = 0.0
+    open_info_delta = 0.0
+
+    if latency_ms < float(OPEN_LATENCY_P10_MS):
+        ignored_reason = "latency"
+    else:
+        if word_count < OPEN_MIN_WORDS or (
+            rubric_conf is not None and rubric_conf < OPEN_MIN_RUBRIC
+        ):
+            eta *= 0.5
+            eta_halved = True
+
+        info_mu = mu * (1.0 - mu)
+        denom = max(info_mu, 1e-6)
+        dtheta = eta * (score - mu) / denom
+        dtheta = max(min(dtheta, DELTA_OPEN_MAX), -DELTA_OPEN_MAX)
+
+        open_info_delta = (A_OPEN * A_OPEN) * info_mu
+        open_total_candidate = domain_state.open_info_total + open_info_delta
+        cap = OPEN_INFO_CAP_RATIO * max(domain_state.obj_info_total, 1e-6)
+
+        if open_total_candidate > cap and cap > 0.0:
+            scale = cap / open_total_candidate if open_total_candidate > 0.0 else 0.0
+            scale = max(min(scale, 1.0), 0.0)
+            if scale < 1.0:
+                dtheta *= scale
+                open_info_delta *= scale
+                scaled = True
+
+        domain_state.theta = theta_before + dtheta
+        domain_state.open_info_total += open_info_delta
+        domain_state.open_info_total = min(domain_state.open_info_total, cap)
+        domain_state.se = rasch.se_from_info(
+            domain_state.info_total + domain_state.open_info_total
+        )
+
+    domain_state.open_count += 1
+    entry: Dict[str, object] = {
+        "b": bucket,
+        "r": float(score),
+        "mu": float(mu),
+        "dtheta": float(dtheta if ignored_reason is None else 0.0),
+        "scaled": bool(scaled),
+    }
+    if ignored_reason is not None:
+        entry["ignored"] = ignored_reason
+    if eta_halved:
+        entry["eta_halved"] = True
+    domain_state.open_contrib.append(entry)
+
+    return {
+        "theta_before": theta_before,
+        "theta_after": domain_state.theta,
+        "b": bucket,
+        "mu": mu,
+        "dtheta": entry["dtheta"],
+        "scaled": scaled,
+        "ignored": ignored_reason,
+        "word_count": word_count,
+        "latency_ms": latency_ms,
+        "eta_halved": eta_halved,
+        "open_info_delta": open_info_delta,
+    }
 
 # Default response-time baselines (seconds)
 DEFAULT_BASE_RT = {"MCQ": 20.0, "SJT": 25.0, "SR": 10.0, "OPEN": 90.0}
@@ -31,6 +539,59 @@ class DomainState:
     sr_sum:      float = 0.0
     sr_total:    int = 0
     max_diff: int = -3
+    theta: float = 0.0
+    info_total: float = 1.0
+    se: float = 1.0
+    level: int = 0
+    level_stats: Dict[int, Dict[str, int]] = field(default_factory=_default_level_stats)
+    recent_window: List[bool] = field(default_factory=list)
+    b_peak: int = 0
+    b_stable: int = 0
+    obj_count: int = 0
+    sr_count: int = 0
+    open_count: int = 0
+    open_contrib: List[Dict[str, object]] = field(default_factory=list)
+    obj_done: bool = False
+    level_entry_seen: int = 0
+    obj_info_total: float = 0.0
+    open_info_total: float = 0.0
+    sr_trap_count: int = 0
+    sr_mirror_ok: bool = True
+    open_debug_reason: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        """JSON-friendly representation used for persistence/debugging."""
+
+        return {
+            "mcq_correct": self.mcq_correct,
+            "mcq_total": self.mcq_total,
+            "sjt_sum": self.sjt_sum,
+            "sjt_total": self.sjt_total,
+            "open_sum": self.open_sum,
+            "open_total": self.open_total,
+            "sr_sum": self.sr_sum,
+            "sr_total": self.sr_total,
+            "max_diff": self.max_diff,
+            "theta": self.theta,
+            "info_total": self.info_total,
+            "se": self.se,
+            "level": self.level,
+            "level_stats": self.level_stats,
+            "recent_window": list(self.recent_window),
+            "b_peak": self.b_peak,
+            "b_stable": self.b_stable,
+            "obj_count": self.obj_count,
+            "sr_count": self.sr_count,
+            "open_count": self.open_count,
+            "open_contrib": list(self.open_contrib),
+            "obj_done": self.obj_done,
+            "level_entry_seen": self.level_entry_seen,
+            "obj_info_total": self.obj_info_total,
+            "open_info_total": self.open_info_total,
+            "sr_trap_count": self.sr_trap_count,
+            "sr_mirror_ok": self.sr_mirror_ok,
+            "open_debug_reason": self.open_debug_reason,
+        }
 
 @dataclass
 class EngineState:
@@ -39,6 +600,7 @@ class EngineState:
     rt_sums: Dict[str, float] = field(default_factory=lambda: {"SR": 0.0, "MCQ": 0.0, "SJT": 0.0, "OPEN": 0.0})
     rt_counts: Dict[str, int] = field(default_factory=lambda: {"SR": 0, "MCQ": 0, "SJT": 0, "OPEN": 0})
     item_rows: List[Dict] = field(default_factory=list)  # per-item audit rows
+    audit_events: List[Dict[str, object]] = field(default_factory=list)
 
 def _safe_frac(num: float, den: float) -> float:
     return float(num) / float(den) if den > 0 else 0.0
@@ -56,31 +618,14 @@ def _open_frac(st: DomainState) -> float:
 def _sr_frac(st: DomainState) -> float:
     return _safe_frac(st.sr_sum, st.sr_total)
 
-def _composite(st: DomainState) -> tuple[float, float, dict]:
-    obj = _obj_frac(st); opn = _open_frac(st); sr = _sr_frac(st)
-    present = {"obj": (st.mcq_total + st.sjt_total) > 0, "open": st.open_total > 0, "sr": st.sr_total > 0}
+def _composite(domain: str, st: DomainState) -> tuple[float, float, dict]:
+    obj = _obj_frac(st)
+    opn = _open_frac(st)
+    sr = _sr_frac(st)
 
-    w_open_eff = (W_OPEN_BASE * (0.5 + 0.5 * obj)) if present["open"] else 0.0
-    w_obj = W_OBJ if present["obj"] else 0.0
-    w_sr  = W_SR  if present["sr"]  else 0.0
-    w_sum = w_open_eff + w_obj + w_sr
-    if w_sum <= 0:
-        return 0.0, 0.60, {"obj": 0.0, "open": 0.0, "sr": 0.0}
-
-    w_open = w_open_eff / w_sum
-    w_obj  = w_obj       / w_sum
-    w_sr   = w_sr        / w_sum
-
-    score = 100.0 * (w_obj * obj + w_open * opn + w_sr * sr)
-
-    var_obj  = (obj * (1 - obj)) / max(1, (st.mcq_total + st.sjt_total)) if present["obj"] else 0.0
-    var_open = (opn * (1 - opn)) / max(1, st.open_total) if present["open"] else 0.0
-    var_sr   = (sr  * (1 - sr )) / max(1, st.sr_total)  if present["sr"]  else 0.0
-    var_total = (w_obj**2)*var_obj + (w_open**2)*var_open + (w_sr**2)*var_sr
-    se = max(0.20, min(0.60, 0.20 + math.sqrt(max(0.0, var_total))))
-
-    parts = {"obj": round(100.0*obj,1), "open": round(100.0*opn,1), "sr": round(100.0*sr,1)}
-    return score, se, parts
+    score = _theta_to_norm_score(st.theta, domain)
+    parts = {"obj": round(100.0 * obj, 1), "open": round(100.0 * opn, 1), "sr": round(100.0 * sr, 1)}
+    return score, st.se, parts
 
 class AdaptiveSession:
     def __init__(self, run_type: str):
@@ -92,12 +637,27 @@ class AdaptiveSession:
         random.shuffle(self.items)
 
         self.asked: set[str] = set()
-        self.seen_variants: set[str] = set()
+        self.seen_variant_groups: set[str] = set()
         self._current: Optional[Item] = None
         self._step = 0
+        self.done: bool = False
+        self.cap_limit = CAP_SHORT if run_type == "short" else CAP_LONG
+        self.global_cap = GLOBAL_STEP_CAP
+        self._finalized_result: Optional[Result] = None
+        self.last_domain_id: Optional[str] = None
+        self._last_item_type: Optional[str] = None
+
+        self._init_domain_levels()
 
         self.policy = QuestionPolicy(self.items, run_type)
         self._id_to_item: Dict[str, Item] = {it.id: it for it in self.items}
+        self._mirror_map: Dict[str, str] = {}
+        for it in self.items:
+            if getattr(it, "type", "") == "SR":
+                partner = getattr(it, "mirror_of", None)
+                if isinstance(partner, str) and partner:
+                    self._mirror_map[it.id] = partner
+                    self._mirror_map.setdefault(partner, it.id)
         self._info_hist: List[float] = []
 
         # load RT baselines if present
@@ -111,54 +671,350 @@ class AdaptiveSession:
         except Exception:
             pass
 
+    def _init_domain_levels(self) -> None:
+        """Initialize ladder starting levels based on SR means or priors."""
+
+        sr_cfg = {}
+        for key in ("sr_means", "sr_mean", "sr_baseline"):
+            val = self.cfg.get(key)
+            if isinstance(val, dict):
+                sr_cfg = val
+                break
+
+        theta_cfg: Dict[str, float] = {}
+        for key in ("theta_priors", "theta_prior", "domain_theta_prior"):
+            val = self.cfg.get(key)
+            if isinstance(val, dict):
+                try:
+                    theta_cfg = {k: float(v) for k, v in val.items()}
+                except Exception:
+                    theta_cfg = {}
+                break
+
+        for domain, st in self.state.domains.items():
+            if self.run_type == "short":
+                start_level = max(min(SHORT_LEVELS[-1], SHORT_START_LEVEL), SHORT_LEVELS[0])
+                st.level = start_level
+                st.recent_window.clear()
+                st.level_entry_seen = 0
+                st.b_peak = start_level
+                st.b_stable = max(st.b_stable, start_level)
+                continue
+
+            base_level = 0
+            sr_mean: Optional[float] = None
+            if st.sr_total > 0:
+                sr_mean = st.sr_sum / max(1, st.sr_total)
+            elif sr_cfg:
+                raw = sr_cfg.get(domain)
+                if raw is not None:
+                    try:
+                        sr_mean = float(raw)
+                    except Exception:
+                        sr_mean = None
+
+            if sr_mean is not None:
+                base_level += _sr_shift_from_mean(sr_mean)
+            base_level = max(-1, min(1, base_level))
+
+            start_level = base_level
+            prior_val = theta_cfg.get(domain)
+            if prior_val is not None:
+                start_level = int(round(prior_val))
+
+            start_level = _clamp_level(start_level)
+            st.level = start_level
+            st.recent_window.clear()
+            st.level_entry_seen = 0
+            st.b_peak = start_level
+            if prior_val is not None:
+                st.b_stable = max(st.b_stable, start_level)
+
     def _policy_state(self) -> PolicyState:
         hist: Dict[str, DomainHistory] = {}
+        theta_map: Dict[str, float] = {}
+        se_map: Dict[str, float] = {}
         for d in DOMAINS:
             dh = DomainHistory()
             dh.asked_ids = [iid for iid in self.asked if self._id_to_item[iid].domain == d]
             st = self.state.domains[d]
-            dh.sr_count   = st.sr_total
-            dh.obj_count  = st.mcq_total + st.sjt_total
-            dh.open_count = st.open_total
+            theta_map[d] = st.theta
+            se_map[d] = st.se
+            dh.sr_count = st.sr_count
+            dh.obj_count = st.obj_count
+            dh.open_count = st.open_count
             denom = float(st.mcq_total + st.sjt_total)
             dh.obj_correct_frac = (st.mcq_correct + st.sjt_sum) / denom if denom > 0 else 0.0
+            dh.level = st.level
+            dh.level_stats = st.level_stats
+            dh.recent_window = list(st.recent_window)
+            dh.level_entry_seen = st.level_entry_seen
+            dh.obj_done = st.obj_done
+            dh.open_contrib = list(st.open_contrib)
+            dh.obj_info_total = st.obj_info_total
+            dh.open_info_total = st.open_info_total
+            dh.b_stable = st.b_stable
+            dh.open_debug_reason = getattr(st, "open_debug_reason", None)
             hist[d] = dh
         return PolicyState(
-            run_type=self.run_type, theta={}, se={}, asked=set(self.asked),
-            seen_variants=set(self.seen_variants), step=self._step, hist=hist,
-            info_history=self._info_hist, mirrored_domains_planned=getattr(self, "_mir_planned", set())
+            run_type=self.run_type, theta=theta_map, se=se_map, asked=set(self.asked),
+            seen_variant_groups=set(self.seen_variant_groups), step=self._step, hist=hist,
+            info_history=self._info_hist, mirrored_domains_planned=getattr(self, "_mir_planned", set()),
+            last_domain_id=self.last_domain_id,
+            last_item_type=self._last_item_type,
         )
 
+    def _update_obj_done(self, st: DomainState) -> None:
+        _, se_target, obj_min, obj_max = _run_parameters(self.run_type)
+        st.obj_done = (
+            (st.obj_count >= obj_min and st.se <= se_target)
+            or st.obj_count >= obj_max
+        )
+
+    def _update_sr_reliability(self, item: Item, answer: Answer, domain_state: DomainState) -> None:
+        if _sr_trap_failed(item, answer):
+            domain_state.sr_trap_count += 1
+
+        partner_id = self._mirror_map.get(item.id)
+        if not partner_id:
+            return
+
+        other_item = self._id_to_item.get(partner_id)
+        other_answer = self.state.answers.get(partner_id)
+        if other_item is None or other_answer is None:
+            return
+
+        current_val = _sr_normalized_value(item, answer)
+        partner_val = _sr_normalized_value(other_item, other_answer)
+        if current_val is None or partner_val is None:
+            return
+
+        if abs(current_val - partner_val) >= 3:
+            domain_state.sr_mirror_ok = False
+
     def next_item(self) -> Optional[Item]:
+        if self.done:
+            return None
+
         st = self._policy_state()
-        if self.policy.should_stop(st): return None
+        if st.step >= self.global_cap:
+            self.done = True
+            return None
+
+        if self.policy.should_stop(st):
+            self.done = True
+            return None
         it = self.policy.next_item(st)
+        if hasattr(self.policy, "_open_debug"):
+            for dom, reason in getattr(self.policy, "_open_debug", {}).items():
+                if dom in self.state.domains:
+                    self.state.domains[dom].open_debug_reason = reason
         self._current = it
+        if it is not None:
+            vg = getattr(it, "variant_group", None)
+            if vg:
+                self.seen_variant_groups.add(vg)
+        else:
+            self.done = True
         return it
 
     def answer_current(self, answer: Answer) -> None:
         if not self._current: return
         it = self._current
-        credit, _ = score_item(it, answer)
+        credit, meta = score_item(it, answer)
 
         ds = self.state.domains[it.domain]
+        rt_ms = 0
         if answer.rt_sec is not None:
-            self.state.rt_sums[it.type] += float(answer.rt_sec)
+            rt_val = float(answer.rt_sec)
+            self.state.rt_sums[it.type] += rt_val
             self.state.rt_counts[it.type] += 1
+            try:
+                rt_ms = max(0, int(round(rt_val * 1000.0)))
+            except Exception:
+                rt_ms = 0
+
+        difficulty = int(getattr(it, "difficulty", 0) or 0)
+        level_bucket = max(min(difficulty, 2), -2)
+        is_obj = it.type in ("MCQ", "SJT")
+
+        level_before_answer = int(ds.level)
+        event_record: Optional[Dict[str, object]] = None
+        timestamp = datetime.now(timezone.utc).isoformat()
+
+        if is_obj:
+            correct_bool = bool(credit >= 0.999) if it.type == "MCQ" else bool(credit >= 0.5)
+            target_level = getattr(it, "_target_level", ds.level)
+            metrics = _apply_objective_step(
+                ds,
+                level_bucket,
+                correct_bool,
+                self.run_type,
+                target_level=target_level,
+            )
+            self._info_hist.append(ds.info_total + ds.open_info_total)
+
+            self._update_obj_done(ds)
+
+            log.debug(
+                (
+                    "rasch_update domain=%s item=%s b=%d correct=%s theta=%.4f->%.4f "
+                    "info=%.4f se=%.4f level=%+d->%+d window=%s stats=%s"
+                ),
+                it.domain,
+                it.id,
+                level_bucket,
+                int(correct_bool),
+                metrics["theta_before"],
+                metrics["theta_after"],
+                metrics["info_delta"],
+                metrics["se"],
+                metrics["level_before"],
+                metrics["level_after"],
+                metrics["window"],
+                metrics["stats"],
+            )
+
+            _emit_trace(
+                domain=it.domain,
+                item_id=it.id,
+                type=it.type,
+                level=ds.level,
+                b=level_bucket,
+                correct_or_r=int(correct_bool),
+                theta_before=metrics["theta_before"],
+                theta_after=metrics["theta_after"],
+                se=ds.se,
+                info_gain=metrics["info_delta"],
+            )
+
+            event_record = {
+                "t": timestamp,
+                "domain": it.domain,
+                "item_id": it.id,
+                "type": it.type,
+                "b": int(level_bucket),
+                "level_before": int(metrics["level_before"]),
+                "level_after": int(metrics["level_after"]),
+                "correct_or_r": 1.0 if correct_bool else 0.0,
+                "theta_before": float(metrics["theta_before"]),
+                "theta_after": float(metrics["theta_after"]),
+                "se_after": float(ds.se),
+                "latency_ms": int(rt_ms),
+            }
 
         if it.type == "MCQ":
             ds.mcq_total += 1
             ds.mcq_correct += 1 if credit >= 0.999 else 0
-            ds.max_diff = max(ds.max_diff, int(getattr(it, "difficulty", 0) or 0))
+            ds.max_diff = max(ds.max_diff, difficulty)
         elif it.type == "SJT":
             ds.sjt_total += 1
             ds.sjt_sum   += float(credit)
         elif it.type == "OPEN":
+            theta_before_open = ds.theta
             ds.open_total += 1
             ds.open_sum   += float(credit)
+
+            text_value = getattr(answer, "value", "")
+            word_count = len(re.findall(r"\w+", str(text_value)))
+            latency_ms = float(answer.rt_sec * 1000.0) if answer.rt_sec is not None else 0.0
+            rubric_conf = None
+            if isinstance(meta, dict):
+                raw_conf = meta.get("rubric_conf")
+                try:
+                    rubric_conf = float(raw_conf) if raw_conf is not None else None
+                except (TypeError, ValueError):
+                    rubric_conf = None
+
+            metrics = _apply_open_step(
+                ds,
+                level_bucket,
+                float(credit),
+                word_count,
+                latency_ms,
+                rubric_conf,
+            )
+            self._update_obj_done(ds)
+            self._info_hist.append(ds.info_total + ds.open_info_total)
+
+            log.debug(
+                (
+                    "open_update domain=%s item=%s b=%d r=%.2f mu=%.3f dtheta=%.4f "
+                    "scaled=%s ignored=%s se=%.4f open_info=%.4f"
+                ),
+                it.domain,
+                it.id,
+                metrics["b"],
+                float(credit),
+                metrics["mu"],
+                metrics["dtheta"],
+                metrics["scaled"],
+                metrics["ignored"],
+                ds.se,
+                ds.open_info_total,
+            )
+
+            _emit_trace(
+                domain=it.domain,
+                item_id=it.id,
+                type=it.type,
+                level=ds.level,
+                b=metrics["b"],
+                correct_or_r=float(credit),
+                theta_before=theta_before_open,
+                theta_after=ds.theta,
+                se=ds.se,
+                info_gain=metrics["open_info_delta"],
+            )
+
+            event_record = {
+                "t": timestamp,
+                "domain": it.domain,
+                "item_id": it.id,
+                "type": it.type,
+                "b": int(metrics["b"]),
+                "level_before": int(level_before_answer),
+                "level_after": int(ds.level),
+                "correct_or_r": float(credit),
+                "theta_before": float(theta_before_open),
+                "theta_after": float(ds.theta),
+                "se_after": float(ds.se),
+                "latency_ms": int(rt_ms),
+            }
         elif it.type == "SR":
+            theta_before_sr = ds.theta
             ds.sr_total += 1
             ds.sr_sum   += float(credit)
+            ds.sr_count += 1
+            self._update_sr_reliability(it, answer, ds)
+
+            _emit_trace(
+                domain=it.domain,
+                item_id=it.id,
+                type=it.type,
+                level=ds.level,
+                b=level_bucket,
+                correct_or_r=float(credit),
+                theta_before=theta_before_sr,
+                theta_after=ds.theta,
+                se=ds.se,
+                info_gain=0.0,
+            )
+
+            event_record = {
+                "t": timestamp,
+                "domain": it.domain,
+                "item_id": it.id,
+                "type": it.type,
+                "b": int(level_bucket),
+                "level_before": int(level_before_answer),
+                "level_after": int(ds.level),
+                "correct_or_r": float(credit),
+                "theta_before": float(theta_before_sr),
+                "theta_after": float(ds.theta),
+                "se_after": float(ds.se),
+                "latency_ms": int(rt_ms),
+            }
 
         # per-item audit row
         self.state.item_rows.append({
@@ -173,11 +1029,35 @@ class AdaptiveSession:
         })
 
         self.asked.add(it.id)
-        if getattr(it, "variant_group", None):
-            self.seen_variants.add(it.variant_group)
+        vg = getattr(it, "variant_group", None)
+        if vg:
+            self.seen_variant_groups.add(vg)
         self.state.answers[it.id] = answer
         self._step += 1
+        self.last_domain_id = it.domain
+        self._last_item_type = it.type
         self._current = None
+
+        if event_record is None:
+            event_record = {
+                "t": timestamp,
+                "domain": it.domain,
+                "item_id": it.id,
+                "type": it.type,
+                "b": int(level_bucket),
+                "level_before": int(level_before_answer),
+                "level_after": int(ds.level),
+                "correct_or_r": float(credit),
+                "theta_before": float(ds.theta),
+                "theta_after": float(ds.theta),
+                "se_after": float(ds.se),
+                "latency_ms": int(rt_ms),
+            }
+
+        self.state.audit_events.append(event_record)
+
+        if self._step >= self.global_cap:
+            self.done = True
 
     def _summary_categories(self) -> Dict[str, float]:
         # Precision = objective accuracy overall
@@ -225,13 +1105,16 @@ class AdaptiveSession:
             pass
 
     def finalize(self) -> Result:
+        if self._finalized_result is not None:
+            return self._finalized_result
+
         asked = [self._id_to_item[iid] for iid in self.asked if iid in self._id_to_item]
         traps = count_traps(asked, self.state.answers)
 
         out_scores: List[DomainScore] = []
         for d in DOMAINS:
             st = self.state.domains[d]
-            score, se, parts = _composite(st)
+            score, composite_se, parts = _composite(d, st)
 
             # A-cap when no OPEN answered
             cap_applied = None
@@ -239,12 +1122,109 @@ class AdaptiveSession:
                 score = 80.0
                 cap_applied = "A"
 
-            ds = DomainScore(domain=d, theta=0.0, se=se, norm_score=round(score, 1),
-                             tier=tier(score), rarity=rarity_label(score))
+            items_by_level: Dict[int, int] = {}
+            accuracy_by_level: Dict[int, float] = {}
+            for lvl_key, stats in (st.level_stats or {}).items():
+                try:
+                    lvl_int = int(lvl_key)
+                except Exception:
+                    continue
+                seen = int(stats.get("seen", 0)) if isinstance(stats, dict) else 0
+                correct = int(stats.get("correct", 0)) if isinstance(stats, dict) else 0
+                items_by_level[lvl_int] = max(seen, 0)
+                accuracy_by_level[lvl_int] = _safe_frac(correct, seen)
+
+            open_ratings: List[float] = []
+            for entry in st.open_contrib:
+                if not isinstance(entry, dict):
+                    continue
+                if entry.get("ignored"):
+                    continue
+                try:
+                    open_ratings.append(float(entry.get("r", 0.0) or 0.0))
+                except Exception:
+                    continue
+
+            norm_ten = score / 10.0
+            tier_state = SimpleNamespace(
+                b_stable=st.b_stable,
+                se=st.se,
+                items_by_level=items_by_level,
+                accuracy_by_level=accuracy_by_level,
+                open_count=st.open_count,
+                open_ratings=open_ratings,
+            )
+            tier_label = map_tier(norm_ten, self.run_type, tier_state)
+            tier_meta = getattr(tier_state, "_tier_meta", {})
+
+            reliability = {
+                "sr_mirror_ok": bool(st.sr_mirror_ok),
+                "trap_count": int(st.sr_trap_count),
+            }
+            ds = DomainScore(
+                domain=d,
+                theta=st.theta,
+                se=st.se,
+                norm_score=round(score, 1),
+                tier=tier_label,
+                rarity=rarity_label(score),
+                reliability=reliability,
+            )
             asked_obj = int(st.mcq_total + st.sjt_total); asked_open = int(st.open_total)
             setattr(ds, "asked_obj", asked_obj); setattr(ds, "asked_open", asked_open); setattr(ds, "n", asked_obj + asked_open)
             setattr(ds, "obj_pct", parts["obj"]); setattr(ds, "open_pct", parts["open"]); setattr(ds, "sr_pct", parts["sr"])
             if cap_applied: setattr(ds, "cap", cap_applied)
+            setattr(ds, "info_total", st.info_total)
+            setattr(ds, "level", st.level)
+            setattr(ds, "level_stats", st.level_stats)
+            setattr(ds, "b_peak", st.b_peak)
+            setattr(ds, "b_stable", st.b_stable)
+            setattr(ds, "obj_count", st.obj_count)
+            setattr(ds, "open_count", st.open_count)
+            setattr(ds, "rasch_se", st.se)
+            setattr(ds, "composite_se", composite_se)
+            setattr(ds, "open_contrib", list(st.open_contrib))
+            setattr(ds, "obj_info_total", st.obj_info_total)
+            setattr(ds, "open_info_total", st.open_info_total)
+            setattr(ds, "open_debug_reason", getattr(st, "open_debug_reason", None))
+            setattr(ds, "items_by_level", items_by_level)
+            setattr(ds, "accuracy_by_level", accuracy_by_level)
+            setattr(ds, "open_ratings", open_ratings)
+            setattr(ds, "norm_ten", norm_ten)
+            setattr(ds, "short_cap_applied", bool(tier_meta.get("short_cap")))
+            setattr(ds, "god_gate", tier_meta.get("god_gate"))
+            setattr(ds, "base_tier", tier_meta.get("base_tier"))
+
+            latencies = [
+                float(row.get("rt_sec", 0.0) or 0.0)
+                for row in self.state.item_rows
+                if row.get("domain") == d and row.get("type") in {"MCQ", "SJT"}
+            ]
+            latencies = [max(0.0, lt) for lt in latencies if isinstance(lt, (int, float))]
+            latency_stats: Dict[str, float] = {}
+            if latencies:
+                latencies.sort()
+
+                def _quantile(q: float) -> float:
+                    if not latencies:
+                        return 0.0
+                    idx = (len(latencies) - 1) * q
+                    lower = int(math.floor(idx))
+                    upper = int(math.ceil(idx))
+                    if lower == upper:
+                        return float(latencies[lower])
+                    low_val = float(latencies[lower])
+                    high_val = float(latencies[upper])
+                    return low_val + (high_val - low_val) * (idx - lower)
+
+                latency_stats = {
+                    "avg": sum(latencies) / len(latencies),
+                    "p10": _quantile(0.10),
+                    "p25": _quantile(0.25),
+                    "p50": _quantile(0.5),
+                    "p75": _quantile(0.75),
+                }
+            setattr(ds, "latency_stats", latency_stats)
             out_scores.append(ds)
 
         top = [x.domain for x in sorted(out_scores, key=lambda x: x.norm_score, reverse=True)[:5]]
@@ -259,6 +1239,11 @@ class AdaptiveSession:
                 conf = "High" if gap>=0.20 else ("Medium" if gap>=0.16 else "Low")
                 hidden.append(HiddenSkill(domain=d, confidence=conf, reason=f"Objective-SR gap {gap:.2f}"))
         hidden = hidden[:5]
+
+        total_items = 0
+        for d in DOMAINS:
+            st = self.state.domains[d]
+            total_items += int(st.mcq_total + st.sjt_total + st.open_total + st.sr_total)
 
         summary = {
             "mean": sum(x.norm_score for x in out_scores)/len(out_scores) if out_scores else 0.0,
@@ -276,13 +1261,140 @@ class AdaptiveSession:
             "consistency_score": cats["consistency_score"],
             # echo baselines used
             "rt_baselines": self.base_rt,
+            "total_items": int(total_items),
         }
+
+        cap = self.cap_limit
+        obj_min = OBJ_MIN_SHORT if self.run_type == "short" else OBJ_MIN_LONG
+        shortfalls = {
+            d: max(0, obj_min - self.state.domains[d].obj_count)
+            for d in DOMAINS
+        }
+        remaining_minima = sum(shortfalls.values())
+        meta = {
+            "run": self.run_type,
+            "cap": cap,
+            "steps_total": int(self._step),
+            "steps_remaining": max(cap - self._step, 0),
+        }
+        if remaining_minima > 0:
+            meta["incomplete"] = True
+            meta["incomplete_reason"] = "CAP_BEFORE_MINIMA"
+            meta["shortfalls"] = {d: v for d, v in shortfalls.items() if v > 0}
+        else:
+            meta["incomplete"] = False
+            meta["shortfalls"] = {}
+
+        summary["steps_total"] = int(self._step)
+        summary["steps_used"] = int(self._step)
+        summary["cap_limit"] = cap
+        summary["cap"] = f"{self._step}/{self.global_cap}"
+        summary["steps_remaining"] = max(cap - self._step, 0)
+        summary["sr_used"] = self.sr_used
+        summary["open_used"] = self.open_used
 
         # Write per-run item CSV
         run_id = os.getenv("RUN_ID", "")
         tag = f"{run_id}_{self.run_type}" if run_id else f"session_{int(time.time())}_{self.run_type}"
         self._write_items_csv(os.path.join("reports", f"{tag}.items.csv"))
 
-        return Result(run_type=self.run_type, domain_scores=out_scores, top_skills=top,
-                      hidden_skills=hidden, traps_tripped=traps, consistency=summary["consistency"],
-                      synergy_boost=0.0, unique_award=None, summary=summary)
+        res = Result(run_type=self.run_type, domain_scores=out_scores, top_skills=top,
+                     hidden_skills=hidden, traps_tripped=traps, consistency=summary["consistency"],
+                     synergy_boost=0.0, unique_award=None, summary=summary)
+        meta["sr_used"] = self.sr_used
+        meta["open_used"] = self.open_used
+        setattr(res, "meta", meta)
+        res.audit_events = [
+            {k: v for k, v in evt.items()}
+            for evt in self.state.audit_events
+        ]
+        self.done = True
+        self._finalized_result = res
+        return res
+
+    @property
+    def steps(self) -> int:
+        return int(self._step)
+
+    @property
+    def sr_used(self) -> int:
+        return int(sum(self.state.domains[d].sr_count for d in DOMAINS))
+
+    @property
+    def open_used(self) -> int:
+        return int(sum(self.state.domains[d].open_count for d in DOMAINS))
+
+    def summary(self) -> Dict[str, object]:
+        cap = self.cap_limit
+        return {
+            "steps_used": int(self._step),
+            "cap_limit": cap,
+            "sr_used": self.sr_used,
+            "open_used": self.open_used,
+        }
+
+    def mark_done(self) -> None:
+        self.done = True
+
+
+def _dev_check_ladder() -> None:
+    """Developer-only assertions for ladder progression and demotion guards."""
+
+    short_seq = [(-1, 1), (-1, 1), (0, 1), (0, 1), (1, 1), (1, 0), (1, 1)]
+    ds_short = DomainState(level=-1)
+    se_values: List[float] = []
+    print("[dev] short run synthetic progression:")
+    for idx, (lvl, correct) in enumerate(short_seq, 1):
+        info = _apply_objective_step(ds_short, lvl, bool(correct), "short", target_level=ds_short.level)
+        se_values.append(ds_short.se)
+        print(
+            f"  step {idx:02d} lvl {info['level_before']:+d}->{info['level_after']:+d} "
+            f"se={ds_short.se:.4f} window={info['window']}"
+        )
+    assert ds_short.level <= 1, "short ladder should stay within band"
+    assert ds_short.obj_count <= OBJ_MAX_SHORT, "short ladder exceeded objective cap"
+    for prev, cur in zip(se_values, se_values[1:]):
+        assert cur <= prev + 1e-6, "SE should not increase in short synthetic run"
+
+    long_seq = [
+        (-1, 1), (-1, 1), (-1, 1), (-1, 0),
+        (0, 1), (0, 1), (0, 1), (0, 0),
+        (1, 1), (1, 1), (1, 1), (1, 0),
+        (2, 1),
+    ]
+    ds_long = DomainState(level=-1)
+    for lvl, correct in long_seq:
+        _apply_objective_step(ds_long, lvl, bool(correct), "long", target_level=ds_long.level)
+    assert ds_long.level == 2, "long ladder should reach +2"
+    assert ds_long.obj_count <= OBJ_MAX_LONG, "long ladder exceeded objective cap"
+
+    ds_demo = DomainState(level=1)
+    ds_demo.recent_window = []
+    ds_demo.level_entry_seen = 0
+    _apply_objective_step(ds_demo, 1, False, "short", target_level=1)
+    assert ds_demo.level == 1, "first miss at new level should not demote"
+    _apply_objective_step(ds_demo, 1, False, "short", target_level=1)
+    _apply_objective_step(ds_demo, 1, False, "short", target_level=1)
+    assert ds_demo.level == 0, "two misses in last three should demote"
+
+    print("[dev] ladder checks passed (short and long sequences, demotion guard).")
+
+
+def _dev_check_sr_behavior() -> None:
+    domain = DOMAINS[0] if DOMAINS else "Analytical"
+    base = DomainState(theta=0.25)
+    score_a, _, _ = _composite(domain, base)
+    heavier_sr = DomainState(theta=0.25, sr_sum=40.0, sr_total=40)
+    score_b, _, _ = _composite(domain, heavier_sr)
+    assert abs(score_a - score_b) < 1e-9, "SR weight should be zero in composite score"
+
+    assert _sr_shift_from_mean(2.0) == SR_START_SHIFT.get("low", -1)
+    assert _sr_shift_from_mean(3.5) == SR_START_SHIFT.get("mid", 0)
+    assert _sr_shift_from_mean(4.8) == SR_START_SHIFT.get("high", 1)
+
+    print("[dev] SR weight & start-level shift checks passed.")
+
+
+if __name__ == "__main__":  # pragma: no cover - developer diagnostics only
+    _dev_check_sr_behavior()
+    _dev_check_ladder()

--- a/skill_core/plan.py
+++ b/skill_core/plan.py
@@ -1,0 +1,457 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
+
+from . import config as cfg_defaults
+
+log = logging.getLogger(__name__)
+
+
+_TIER_ORDER: Dict[str, int] = {
+    "F": 0,
+    "D": 1,
+    "C": 2,
+    "B": 3,
+    "A": 4,
+    "S": 5,
+    "SS": 6,
+}
+
+_DEFAULT_CONCEPTS: Dict[str, Sequence[str]] = {
+    "Analytical": ("data comparisons", "ratio reasoning"),
+    "Mathematical": ("algebra refresh", "multi-step calculations"),
+    "Verbal": ("tone shifts", "evidence mapping"),
+    "Memory": ("mnemonic chains", "chunking patterns"),
+    "Spatial": ("rotation drills", "perspective shifts"),
+    "Creativity": ("idea expansion", "divergent prompts"),
+    "Strategy": ("scenario planning", "trade-off mapping"),
+    "Social": ("empathy cues", "influence levers"),
+}
+
+_DEFAULT_RESOURCES: Dict[str, str] = {
+    "Analytical": "Use weekly case sets and chart summaries to reinforce comparisons.",
+    "Mathematical": "Schedule two short sessions with the SkillTier problem generator to review formulas.",
+    "Verbal": "Summarise two editorials aloud, focusing on evidence statements.",
+    "Memory": "Build a spaced-repetition deck for current projects.",
+    "Spatial": "Sketch three perspective drawings to solidify rotation intuition.",
+    "Creativity": "Run a 10-minute idea sprint with SCAMPER prompts twice this week.",
+    "Strategy": "Deconstruct a recent decision memo and note three alternative plays.",
+    "Social": "Role-play two stakeholder conversations focusing on active listening cues.",
+}
+
+
+@dataclass(frozen=True)
+class PlanSettings:
+    enabled: bool
+    long_only: bool
+    focus_max: int
+    bullets_min: int
+    bullets_max: int
+    min_items_long: int
+    se_target_long: float
+    llm_enabled: bool
+    latency_buckets: Tuple[float, float]
+
+    @staticmethod
+    def from_cfg(cfg: Mapping[str, Any] | None) -> "PlanSettings":
+        def _cfg_value(name: str, default: Any) -> Any:
+            if cfg is None:
+                return default
+            if isinstance(cfg, Mapping) and name in cfg:
+                return cfg[name]
+            return getattr(cfg, name, default) if hasattr(cfg, name) else default
+
+        buckets = _cfg_value("PLAN_LATENCY_BUCKETS", cfg_defaults.PLAN_LATENCY_BUCKETS)
+        if isinstance(buckets, Sequence) and len(buckets) >= 2:
+            latency_buckets = (float(buckets[0]), float(buckets[1]))
+        else:
+            latency_buckets = cfg_defaults.PLAN_LATENCY_BUCKETS
+
+        return PlanSettings(
+            enabled=bool(_cfg_value("PLAN_ENABLED", cfg_defaults.PLAN_ENABLED)),
+            long_only=bool(_cfg_value("PLAN_LONG_ONLY", cfg_defaults.PLAN_LONG_ONLY)),
+            focus_max=int(_cfg_value("PLAN_FOCUS_MAX", cfg_defaults.PLAN_FOCUS_MAX)),
+            bullets_min=int(_cfg_value("PLAN_BULLETS_MIN", cfg_defaults.PLAN_BULLETS_MIN)),
+            bullets_max=int(_cfg_value("PLAN_BULLETS_MAX", cfg_defaults.PLAN_BULLETS_MAX)),
+            min_items_long=int(_cfg_value("PLAN_MIN_ITEMS_LONG", cfg_defaults.PLAN_MIN_ITEMS_LONG)),
+            se_target_long=float(_cfg_value("PLAN_SE_TARGET_LONG", cfg_defaults.PLAN_SE_TARGET_LONG)),
+            llm_enabled=bool(_cfg_value("PLAN_LLM_ENABLED", cfg_defaults.PLAN_LLM_ENABLED)),
+            latency_buckets=latency_buckets,
+        )
+
+
+def _as_dict(obj: Any) -> Dict[str, Any]:
+    if isinstance(obj, dict):
+        return dict(obj)
+    if hasattr(obj, "__dict__"):
+        return dict(obj.__dict__)
+    return {}
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return default
+
+
+def _tier_rank(value: Any) -> int:
+    tier = str(value or "").upper().strip()
+    return _TIER_ORDER.get(tier, len(_TIER_ORDER))
+
+
+def _clamp_level(level: int) -> int:
+    lo = getattr(cfg_defaults, "LEVEL_MIN", -2)
+    hi = getattr(cfg_defaults, "LEVEL_MAX", 2)
+    return max(lo, min(hi, int(level)))
+
+
+def _extract_concept_tag(domain: str, tags: Iterable[Any]) -> Tuple[str, bool]:
+    for raw in tags or []:
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip(), True
+        if isinstance(raw, Mapping):
+            for key in ("tag", "label", "name"):
+                val = raw.get(key)
+                if isinstance(val, str) and val.strip():
+                    return val.strip(), True
+    fallback = _DEFAULT_CONCEPTS.get(domain)
+    if fallback:
+        return fallback[0], False
+    return "core patterns", False
+
+
+def _timing_targets(
+    domain_stats: Mapping[str, Any],
+    summary: Mapping[str, Any],
+    settings: PlanSettings,
+) -> Tuple[int, int, int]:
+    stats = domain_stats.get("latency_stats") if isinstance(domain_stats, Mapping) else None
+    low = high = quick = 0
+    if isinstance(stats, Mapping) and stats:
+        low = round(max(1.0, _safe_float(stats.get("p25"), 0.0)))
+        high = round(max(low + 1.0, _safe_float(stats.get("p75"), 0.0)))
+        quick = round(max(1.0, _safe_float(stats.get("p10"), low * 0.6)))
+    else:
+        avg_rt = _safe_float(summary.get("avg_rt_mcq"), 25.0)
+        low = round(max(1.0, avg_rt * settings.latency_buckets[0]))
+        high = round(max(low + 1.0, avg_rt * settings.latency_buckets[1]))
+        quick = round(max(1.0, low * 0.6))
+    if quick >= low:
+        quick = max(1, low - 2)
+    return max(1, low), max(low + 1, high), max(1, quick)
+
+
+def _build_domain_plan(
+    domain_stats: Mapping[str, Any],
+    summary: Mapping[str, Any],
+    settings: PlanSettings,
+) -> Dict[str, Any]:
+    domain = str(domain_stats.get("domain") or "Domain")
+    theta = _safe_float(domain_stats.get("theta"), 0.0)
+    b_stable = _safe_int(domain_stats.get("b_stable"), 0)
+    level_val = _clamp_level(max(b_stable, round(theta)))
+    level_label = f"{level_val:+d}"
+
+    accuracy_map = domain_stats.get("accuracy_by_level") if isinstance(domain_stats, Mapping) else {}
+    level_acc = 0.0
+    if isinstance(accuracy_map, Mapping):
+        if level_val in accuracy_map:
+            level_acc = _safe_float(accuracy_map.get(level_val), 0.0)
+        elif str(level_val) in accuracy_map:
+            level_acc = _safe_float(accuracy_map.get(str(level_val)), 0.0)
+
+    items_map = domain_stats.get("items_by_level") if isinstance(domain_stats, Mapping) else {}
+    level_seen = 0
+    if isinstance(items_map, Mapping):
+        if level_val in items_map:
+            level_seen = _safe_int(items_map.get(level_val), 0)
+        elif str(level_val) in items_map:
+            level_seen = _safe_int(items_map.get(str(level_val)), 0)
+
+    drill_text = (
+        f"Practice level {level_label} sets with deliberate review. "
+        f"Baseline: {level_acc*100:.0f}% over {level_seen} items."
+        if level_seen
+        else f"Practice level {level_label} sets with deliberate review."
+    )
+    drill_goal = {
+        "type": "drill",
+        "text": drill_text,
+        "measure": "Goal: ≥8/10 correct twice this week.",
+    }
+
+    concept_tag, concept_specific = _extract_concept_tag(
+        domain, domain_stats.get("missed_tags") if isinstance(domain_stats, Mapping) else []
+    )
+    concept_goal = {
+        "type": "concept",
+        "tag": concept_tag,
+        "text": (
+            f"Design a micro-review on {concept_tag} and teach it back in 10 minutes."
+            if concept_specific
+            else f"Run a focused refresher on {concept_tag}; capture three takeaways."
+        ),
+    }
+
+    low_t, high_t, quick_t = _timing_targets(domain_stats, summary, settings)
+    timing_goal = {
+        "type": "timing",
+        "text": (
+            f"Answer level {level_label} items between {low_t}-{high_t}s; avoid guesses faster than {quick_t}s."
+        ),
+    }
+
+    next_level = _clamp_level(level_val + 1)
+    if next_level == level_val:
+        challenge_text = (
+            f"Sustain level {level_label} mastery with weekly mixed sets; pass = 3/4 correct."
+        )
+    else:
+        challenge_label = f"{next_level:+d}"
+        challenge_text = (
+            f"Attempt a level {challenge_label} mini-set after each drill; pass = 3/4 correct."
+        )
+    challenge_goal = {
+        "type": "challenge",
+        "text": challenge_text,
+        "measure": "Document outcomes in a shared log.",
+    }
+
+    resource_text = _DEFAULT_RESOURCES.get(
+        domain, "Use the SkillTier practice generator for two targeted sessions."
+    )
+    resource_goal = {
+        "type": "resource",
+        "text": resource_text,
+    }
+
+    goals: List[Dict[str, Any]] = [
+        drill_goal,
+        concept_goal,
+        timing_goal,
+        challenge_goal,
+        resource_goal,
+    ]
+
+    if settings.bullets_max < len(goals):
+        goals = goals[: settings.bullets_max]
+    if len(goals) < settings.bullets_min:
+        goals.extend(goals[: max(0, settings.bullets_min - len(goals))])
+
+    goals = _maybe_rewrite_with_llm(domain, level_label, goals, settings)
+
+    if len(goals) > settings.bullets_max:
+        goals = goals[: settings.bullets_max]
+
+    if len(goals) < settings.bullets_min:
+        seed = goals or [drill_goal]
+        idx = 0
+        while len(goals) < settings.bullets_min:
+            goals.append(dict(seed[idx % len(seed)]))
+            idx += 1
+
+    return {
+        "domain": domain,
+        "level": level_label,
+        "goals": goals,
+    }
+
+
+def _maybe_rewrite_with_llm(
+    domain: str,
+    level_label: str,
+    goals: List[Dict[str, Any]],
+    settings: PlanSettings,
+) -> List[Dict[str, Any]]:
+    if not settings.llm_enabled:
+        return goals
+    try:
+        from . import llm_bridge
+
+        backend = llm_bridge.backend_in_use()
+        if backend != "azure":
+            return goals
+
+        from .azure_cfg import client as azure_client
+
+        payload = {"domain": domain, "level": level_label, "goals": goals}
+        prompt = (
+            "You are a coaching assistant. Rewrite the goals to sound supportive, clear, and time-bound. "
+            "Preserve each goal's type/tag/measure fields. Return ONLY JSON matching the input structure.\n"
+            f"Input: {json.dumps(payload, ensure_ascii=False)}"
+        )
+        cli = azure_client()
+        resp = cli.chat.completions.create(
+            model=llm_bridge.azure_settings().deployment,
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You rewrite improvement plans. Respond strictly with valid JSON matching the input schema."
+                    ),
+                },
+                {"role": "user", "content": prompt},
+            ],
+            temperature=0.2,
+            top_p=0.9,
+            max_tokens=500,
+        )
+        content = resp.choices[0].message.content if resp.choices else None
+        if not content:
+            return goals
+        data = json.loads(content)
+        new_goals = data.get("goals") if isinstance(data, dict) else data
+        parsed: List[Dict[str, Any]] = []
+        for g in new_goals or []:
+            if isinstance(g, Mapping) and "type" in g and "text" in g:
+                parsed.append(dict(g))
+        return parsed or goals
+    except Exception as exc:  # pragma: no cover - optional path
+        log.debug("plan LLM fallback: %s", exc)
+        return goals
+
+
+def _domain_sort_key(domain_stats: Mapping[str, Any]) -> Tuple[int, float, int]:
+    tier_rank = _tier_rank(domain_stats.get("tier"))
+    se_val = _safe_float(domain_stats.get("se", domain_stats.get("rasch_se")), 1.0)
+    b_stable = _safe_int(domain_stats.get("b_stable"), 0)
+    return (tier_rank, -se_val, b_stable)
+
+
+def _domain_se(domain_stats: Mapping[str, Any]) -> float:
+    return _safe_float(domain_stats.get("se", domain_stats.get("rasch_se")), 1.0)
+
+
+def _total_items(domains: Sequence[Mapping[str, Any]], summary: Mapping[str, Any]) -> int:
+    total = 0
+    for dom in domains:
+        if not isinstance(dom, Mapping):
+            continue
+        if "n" in dom:
+            total += _safe_int(dom.get("n"), 0)
+        else:
+            obj = _safe_int(dom.get("asked_obj"), 0)
+            open_n = _safe_int(dom.get("asked_open"), 0)
+            total += obj + open_n
+    if total <= 0 and isinstance(summary, Mapping):
+        total = _safe_int(summary.get("total_items"), 0)
+    return max(0, total)
+
+
+def generate_plan(result: Any, cfg: Mapping[str, Any] | None) -> List[Dict[str, Any]]:
+    """Generate a SMART improvement plan for long adaptive runs.
+
+    Parameters
+    ----------
+    result:
+        Finalized result payload (dict or Result dataclass) including `domain_scores` and `summary`.
+    cfg:
+        Configuration mapping (typically output of :func:`skill_core.config.load_config`).
+
+    Returns
+    -------
+    list of dict
+        List of domain plans (each containing domain, level, goals). Empty when disabled.
+    """
+
+    settings = PlanSettings.from_cfg(cfg)
+    if not settings.enabled:
+        return []
+
+    result_dict = _as_dict(result)
+    run_type = str(
+        result_dict.get("run_type")
+        or (result_dict.get("meta") or {}).get("run")
+        or (result_dict.get("meta") or {}).get("kind")
+        or ""
+    ).lower()
+
+    if settings.long_only and run_type != "long":
+        return []
+
+    domains_raw = result_dict.get("domain_scores") or []
+    domains: List[Dict[str, Any]] = [_as_dict(d) for d in domains_raw if d is not None]
+    if not domains:
+        return []
+
+    summary = result_dict.get("summary") or {}
+    total_items = _total_items(domains, summary)
+
+    focus_max = max(1, settings.focus_max)
+    if run_type == "long" and total_items and total_items < settings.min_items_long:
+        focus_max = min(focus_max, 2)
+
+    domains_sorted = sorted(domains, key=_domain_sort_key)
+
+    priority = [d for d in domains_sorted if _domain_se(d) >= settings.se_target_long]
+    fallback = [d for d in domains_sorted if d not in priority]
+    ordered = priority + fallback
+
+    focus_count = min(len(ordered), focus_max)
+    if focus_count < 2 and len(ordered) >= 2:
+        focus_count = 2
+    ordered = ordered[:focus_count]
+
+    plan = [
+        _build_domain_plan(domain_stats, summary, settings)
+        for domain_stats in ordered
+    ]
+
+    return plan
+
+
+def _demo_plan() -> None:  # pragma: no cover - developer aid
+    sample_result = {
+        "run_type": "long",
+        "summary": {
+            "avg_rt_mcq": 28.0,
+            "total_items": 96,
+        },
+        "domain_scores": [
+            {
+                "domain": "Analytical",
+                "tier": "C",
+                "theta": -0.2,
+                "se": 0.32,
+                "b_stable": 0,
+                "accuracy_by_level": {0: 0.55},
+                "items_by_level": {0: 9},
+                "latency_stats": {"p10": 8.0, "p25": 15.0, "p50": 24.0, "p75": 36.0},
+            },
+            {
+                "domain": "Verbal",
+                "tier": "B",
+                "theta": 0.15,
+                "se": 0.41,
+                "b_stable": 0,
+                "accuracy_by_level": {0: 0.62},
+                "items_by_level": {0: 11},
+            },
+            {
+                "domain": "Strategy",
+                "tier": "A",
+                "theta": 0.8,
+                "se": 0.27,
+                "b_stable": 1,
+                "accuracy_by_level": {1: 0.67},
+                "items_by_level": {1: 12},
+            },
+        ],
+    }
+
+    plan = generate_plan(sample_result, None)
+    print(json.dumps(plan, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover - developer diagnostics
+    _demo_plan()
+

--- a/skill_core/policy.py
+++ b/skill_core/policy.py
@@ -1,17 +1,69 @@
 # skill_core/policy.py
 from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Dict, List, Set, Optional
-import os, random
+from typing import Dict, List, Set, Optional, Tuple
+import math
+import random
+
 from .question_bank import DOMAINS
+from .config import (
+    SE_TARGET_SHORT,
+    SE_TARGET_LONG,
+    SHORT_OBJ_MIN,
+    SHORT_OBJ_MAX,
+    OBJ_MIN_LONG,
+    OBJ_MAX_LONG,
+    LEVEL_MIN,
+    LEVEL_MAX,
+    CAP_SHORT,
+    CAP_LONG,
+    GLOBAL_STEP_CAP,
+    OPEN_ENABLED_LONG,
+    OPEN_GATE1_MIN_OBJ,
+    OPEN_GATE1_SE_MAX,
+    OPEN_GATE2_SE_MAX,
+    OPEN_GATE2_MIN_R1,
+    OPEN_LEVELS,
+    OPEN_Z_SHIFT,
+    OPEN_FALLBACK_AFTER_OBJ,
+    OPEN_FALLBACK_MIN_STABLE,
+    OPEN_DEBUG_REASON,
+    SHORT_SR_PER_DOMAIN,
+    SHORT_EXTRA_TOTAL,
+    SR_PER_DOMAIN_LONG,
+    SHORT_LEVELS,
+    SHORT_START_LEVEL,
+    STAGING_PROFILE,
+    TEST_MODE,
+    TEST_OPEN_FULL,
+    OPEN_RESERVE_FORCE,
+    DEBUG_SEED,
+)
+
+
+def _clamp_level(level: int) -> int:
+    return max(LEVEL_MIN, min(LEVEL_MAX, int(level)))
+
 
 @dataclass
 class DomainHistory:
     asked_ids: List[str] = field(default_factory=list)
-    sr_count:   int = 0
-    obj_count:  int = 0     # MCQ + SJT
+    sr_count: int = 0
+    obj_count: int = 0
     open_count: int = 0
-    obj_correct_frac: float = 0.0  # 0..1 objective accuracy for gating
+    obj_correct_frac: float = 0.0
+    level: int = 0
+    level_stats: Dict[int, Dict[str, int]] = field(default_factory=dict)
+    recent_window: List[bool] = field(default_factory=list)
+    level_entry_seen: int = 0
+    obj_done: bool = False
+    open_contrib: List[Dict[str, object]] = field(default_factory=list)
+    obj_info_total: float = 0.0
+    open_info_total: float = 0.0
+    b_stable: int = 0
+    open_debug_reason: Optional[str] = None
+
 
 @dataclass
 class PolicyState:
@@ -19,123 +71,741 @@ class PolicyState:
     theta: Dict[str, float]
     se: Dict[str, float]
     asked: Set[str]
-    seen_variants: Set[str]
+    seen_variant_groups: Set[str]
     step: int
     hist: Dict[str, DomainHistory]
     info_history: List[float]
     mirrored_domains_planned: Set[str] = field(default_factory=set)
+    last_domain_id: Optional[str] = None
+    last_item_type: Optional[str] = None
+
 
 class QuestionPolicy:
-    """
-    Count-based policy with OPEN eligibility.
-    Short: no OPEN by default (cap handles ceiling). Enable via SHORT_ALLOW_OPEN=1 to include at most 1 OPEN/domain when eligible.
-    Long: OBJ and SR quotas, OPEN required when eligible. On autoplay 'perfect', force ≥1 OPEN/domain.
-    """
+    """Difficulty-aware ladder policy with per-domain rotation guards."""
 
     def __init__(self, items: List, run_type: str):
         self.run_type = run_type if run_type in ("short", "long") else "long"
         self.items = items
-        idx: Dict[str, Dict[str, List]] = {d: {"MCQ": [], "SJT": [], "OPEN": [], "SR": []} for d in DOMAINS}
+        self._domain_index = {d: idx for idx, d in enumerate(DOMAINS)}
+        seed = DEBUG_SEED
+        if seed is None:
+            seed = random.randint(0, 2**31 - 1)
+        self.rng = random.Random(int(seed))
+
+        levels = range(LEVEL_MIN, LEVEL_MAX + 1)
+        self._obj_index: Dict[str, Dict[int, List]] = {
+            d: {lvl: [] for lvl in levels} for d in DOMAINS
+        }
+        self._sr_index: Dict[str, List] = {d: [] for d in DOMAINS}
+        self._open_levels: Tuple[int, ...] = tuple(sorted({int(lvl) for lvl in OPEN_LEVELS}))
+        self._open_index: Dict[str, Dict[int, List]] = {
+            d: {lvl: [] for lvl in self._open_levels} for d in DOMAINS
+        }
+        self._short_levels: Tuple[int, ...] = tuple(sorted({int(lvl) for lvl in SHORT_LEVELS}))
+        self._short_min = self._short_levels[0] if self._short_levels else -1
+        self._short_max = self._short_levels[-1] if self._short_levels else 1
+        self._last_pick_was_sr = False
+        self._open_debug: Dict[str, Optional[str]] = {d: None for d in DOMAINS}
+        self._short_extra_domains: Optional[List[str]] = None
+
         for it in items:
-            d = getattr(it, "domain", None)
-            t = getattr(it, "type", None)
-            if d in idx and t in idx[d]:
-                idx[d][t].append(it)
-        self.idx = idx
+            domain = getattr(it, "domain", None)
+            if domain not in self._obj_index:
+                continue
+            typ = getattr(it, "type", None)
+            if typ in ("MCQ", "SJT"):
+                lvl = _clamp_level(int(getattr(it, "difficulty", 0) or 0))
+                self._obj_index[domain][lvl].append(it)
+            elif typ == "SR":
+                self._sr_index[domain].append(it)
+            elif typ == "OPEN":
+                raw_lvl = int(getattr(it, "difficulty", 0) or 0)
+                lvl = max(self._open_levels[0], min(self._open_levels[-1], raw_lvl))
+                if lvl in self._open_index[domain]:
+                    self._open_index[domain][lvl].append(it)
 
-        self.max_steps = 56 if self.run_type == "short" else 120
-        self.MIN_OBJ_FOR_OPEN = 2 if self.run_type == "short" else 4
-        self.MIN_OBJ_ACC_FOR_OPEN = 0.60
+    @staticmethod
+    def _bounds(run_type: str) -> tuple[float, int, int, int]:
+        if run_type == "short":
+            return SE_TARGET_SHORT, SHORT_OBJ_MIN, SHORT_OBJ_MAX, SHORT_SR_PER_DOMAIN
+        return SE_TARGET_LONG, OBJ_MIN_LONG, OBJ_MAX_LONG, SR_PER_DOMAIN_LONG
 
-        self.short_allow_open = os.getenv("SHORT_ALLOW_OPEN", "0") == "1"
-        self.force_open_each_domain = (os.getenv("PROFILE", "").lower() == "perfect" and self.run_type == "long")
+    @staticmethod
+    def _cap_for(run_type: str) -> int:
+        return CAP_SHORT if run_type == "short" else CAP_LONG
 
-    def _quotas(self) -> Dict[str, Dict[str, int]]:
-        if self.run_type == "short":
-            # default: no OPENs in short
-            open_q = 1 if self.short_allow_open else 0
-            return {d: {"OBJ": 4, "OPEN": open_q, "SR": 2} for d in DOMAINS}
-        # long
-        return {d: {"OBJ": 8, "OPEN": 2, "SR": 2} for d in DOMAINS}
+    def _should_stop_short(self, st: PolicyState) -> bool:
+        if st.step >= CAP_SHORT:
+            return True
 
-    def _counts(self, st: PolicyState, d: str) -> Dict[str, int]:
-        h = st.hist.get(d, DomainHistory())
-        return {"OBJ": int(h.obj_count), "OPEN": int(h.open_count), "SR": int(h.sr_count)}
-
-    def _eligible_for_open(self, st: PolicyState, d: str) -> bool:
-        if not self.idx.get(d, {}).get("OPEN"):
+        if any(
+            st.hist.get(d, DomainHistory()).obj_count < SHORT_OBJ_MIN for d in DOMAINS
+        ):
             return False
-        if self.force_open_each_domain:
-            return True
-        h = st.hist.get(d, DomainHistory())
-        return (h.obj_count >= self.MIN_OBJ_FOR_OPEN) and (h.obj_correct_frac >= self.MIN_OBJ_ACC_FOR_OPEN)
 
-    def should_stop(self, st: PolicyState) -> bool:
-        if st.step >= self.max_steps:
-            return True
-        quotas = self._quotas()
-        for d in DOMAINS:
-            q = quotas[d]; c = self._counts(st, d)
-            if c["OBJ"] < q["OBJ"] or c["SR"] < q["SR"]:
-                return False
-            # OPEN only matters if quota>0 and eligible
-            if q["OPEN"] > 0 and self._eligible_for_open(st, d):
-                if c["OPEN"] < q["OPEN"]:
+        if SHORT_SR_PER_DOMAIN > 0:
+            for dom in DOMAINS:
+                hist = st.hist.get(dom, DomainHistory())
+                if hist.sr_count < SHORT_SR_PER_DOMAIN and self._sr_available(dom, st):
                     return False
+
+        extras_total = sum(
+            max(0, st.hist.get(dom, DomainHistory()).obj_count - SHORT_OBJ_MIN)
+            for dom in DOMAINS
+        )
+        if extras_total >= SHORT_EXTRA_TOTAL:
+            return True
+
+        target_domains = self._short_extra_domains or DOMAINS
+        for dom in target_domains:
+            hist = st.hist.get(dom, DomainHistory())
+            if hist.obj_count >= SHORT_OBJ_MAX:
+                continue
+            if max(0, hist.obj_count - SHORT_OBJ_MIN) >= 2:
+                continue
+            if self._objective_available(dom, st):
+                return False
+
         return True
 
-    def _domain_deficit(self, st: PolicyState, d: str) -> Dict[str, int]:
-        q = self._quotas()[d]; c = self._counts(st, d)
-        def_map = {k: max(0, q[k] - c[k]) for k in ("OBJ", "OPEN", "SR")}
-        if q["OPEN"] == 0 or not self._eligible_for_open(st, d):
-            def_map["OPEN"] = 0
-        return def_map
+    def should_stop(self, st: PolicyState) -> bool:
+        if st.run_type == "short":
+            return self._should_stop_short(st)
 
-    def _pick_domain(self, st: PolicyState) -> Optional[str]:
-        best_d, best_key = None, (-1, -1)
-        for d in DOMAINS:
-            h = st.hist.get(d, DomainHistory())
-            def_map = self._domain_deficit(st, d)
-            total_def = def_map["OBJ"] + def_map["OPEN"] + def_map["SR"]
-            key = (total_def, -len(h.asked_ids))
-            if key > best_key:
-                best_d, best_key = d, key
-        return best_d
+        _, obj_min, obj_max, sr_required = self._bounds(st.run_type)
+        cap = self._cap_for(st.run_type)
 
-    def _pick_type(self, st: PolicyState, d: str) -> str:
-        def_map = self._domain_deficit(st, d)
-        # prefer OBJ > OPEN > SR
-        order = ["OBJ", "OPEN", "SR"]
-        order.sort(key=lambda k: (-def_map[k], {"OBJ":0, "OPEN":1, "SR":2}[k]))
-        choice = order[0]
-        if choice == "OPEN" and (self._quotas()[d]["OPEN"] == 0 or not self._eligible_for_open(st, d)):
-            choice = "OBJ" if def_map["OBJ"] > 0 else "SR"
-        return choice
-
-    def _candidates(self, d: str, typ: str) -> List:
-        if typ == "OBJ":
-            return (self.idx[d]["MCQ"] or []) + (self.idx[d]["SJT"] or [])
-        return self.idx[d][typ]
-
-    def next_item(self, st: PolicyState):
-        d = self._pick_domain(st)
-        if d is None:
-            return None
-        typ_choice = self._pick_type(st, d)
-        pool = self._candidates(d, typ_choice)
-
-        def unseen(it) -> bool:
-            iid = getattr(it, "id", "")
-            vg = getattr(it, "variant_group", None)
-            if iid in st.asked: return False
-            if vg and vg in st.seen_variants: return False
+        if st.step >= cap:
             return True
 
-        cand = [it for it in pool if unseen(it)]
-        if not cand:
-            any_dom = [it for it in (self.idx[d]["MCQ"] + self.idx[d]["SJT"] + self.idx[d]["OPEN"] + self.idx[d]["SR"]) if unseen(it)]
-            if not any_dom:
-                all_unseen = [it for it in self.items if getattr(it, "id", "") not in st.asked]
-                return random.choice(all_unseen) if all_unseen else None
-            return random.choice(any_dom)
-        return random.choice(cand)
+        remaining_obj_minima = sum(
+            max(0, obj_min - st.hist.get(d, DomainHistory()).obj_count)
+            for d in DOMAINS
+        )
+        if remaining_obj_minima > 0:
+            return False
+
+        for d in DOMAINS:
+            hist = st.hist.get(d, DomainHistory())
+            if not hist.obj_done and hist.obj_count < obj_max:
+                return False
+
+        sr_needed = 0
+        if sr_required > 0:
+            sr_needed = sum(
+                max(0, sr_required - st.hist.get(d, DomainHistory()).sr_count)
+                for d in DOMAINS
+            )
+            if sr_needed > 0:
+                if any(
+                    st.hist.get(d, DomainHistory()).sr_count < sr_required
+                    and self._sr_available(d, st)
+                    for d in DOMAINS
+                ):
+                    return False
+                return True
+
+        if self.run_type == "long" and OPEN_ENABLED_LONG and sr_needed == 0:
+            if self._open_candidate_exists(st, obj_min):
+                return False
+
+        return False
+
+    def next_item(self, st: PolicyState):
+        if st.run_type == "short":
+            return self._next_item_short(st)
+
+        se_target, obj_min, obj_max, sr_required = self._bounds(st.run_type)
+        cap = self._cap_for(st.run_type)
+        steps_left = max(cap - st.step, 0)
+        if steps_left <= 0:
+            return None
+
+        remaining_obj_minima = [
+            d for d in DOMAINS if st.hist.get(d, DomainHistory()).obj_count < obj_min
+        ]
+        if remaining_obj_minima:
+            domains = self._sort_candidates(remaining_obj_minima, st)
+            item = self._serve_objective(domains, st)
+            if item:
+                self._last_pick_was_sr = False
+            return item
+
+        stage_b = [
+            d
+            for d in DOMAINS
+            if not st.hist.get(d, DomainHistory()).obj_done
+            and st.se.get(d, 0.0) > se_target
+        ]
+        stage_c = [
+            d
+            for d in DOMAINS
+            if not st.hist.get(d, DomainHistory()).obj_done
+            and st.hist.get(d, DomainHistory()).obj_count < obj_max
+        ]
+
+        sr_needed = 0
+        if sr_required > 0:
+            sr_needed = sum(
+                max(0, sr_required - st.hist.get(d, DomainHistory()).sr_count)
+                for d in DOMAINS
+            )
+
+        sr_only = sr_needed > 0 and steps_left <= sr_needed
+        if sr_needed > 0:
+            sr_domain = self._sr_domain(st, obj_min, sr_required)
+            if sr_domain is None and sr_only:
+                return None
+            if sr_domain is not None and (
+                sr_only or (not self._last_pick_was_sr or (not stage_b and not stage_c))
+            ):
+                item = self._pick_sr_item(sr_domain, st)
+                if item:
+                    setattr(item, "_target_level", None)
+                    setattr(item, "_served_level", None)
+                    self._last_pick_was_sr = True
+                    return item
+
+        open_item = self._maybe_serve_open(st, obj_min, sr_needed)
+        if open_item is not None:
+            self._last_pick_was_sr = False
+            return open_item
+
+        if stage_b:
+            domains = self._sort_candidates(stage_b, st)
+            item = self._serve_objective(domains, st)
+            if item:
+                self._last_pick_was_sr = False
+                return item
+
+        if stage_c:
+            domains = self._sort_candidates(stage_c, st)
+            item = self._serve_objective(domains, st)
+            if item:
+                self._last_pick_was_sr = False
+                return item
+
+        item = self._fallback_objective(st)
+        self._last_pick_was_sr = False
+        return item
+
+    def _sort_candidates(self, domains: List[str], st: PolicyState) -> List[str]:
+        def key(dom: str) -> tuple:
+            se_val = st.se.get(dom, 0.0)
+            obj_count = st.hist.get(dom, DomainHistory()).obj_count
+            rotation = 0 if st.last_domain_id == dom else -1
+            return (-se_val, obj_count, rotation, self._domain_index[dom])
+
+        return sorted(domains, key=key)
+
+    def _level_order(self, base_level: int) -> List[int]:
+        order: List[int] = []
+        for delta in (0, 1, -1, 2, -2):
+            lvl = _clamp_level(base_level + delta)
+            if lvl not in order:
+                order.append(lvl)
+        return order
+
+    def _short_level_order(self, base_level: int) -> List[int]:
+        base = max(self._short_min, min(self._short_max, int(base_level)))
+        order: List[int] = []
+        for delta in (0, 1, -1):
+            lvl = max(self._short_min, min(self._short_max, base + delta))
+            if lvl not in order:
+                order.append(lvl)
+        for lvl in self._short_levels:
+            if lvl not in order:
+                order.append(lvl)
+        return order
+
+    def _open_level_order(self, preferred: int) -> List[int]:
+        def key(lvl: int) -> Tuple[float, int]:
+            return (abs(lvl - preferred), -lvl)
+
+        return sorted(self._open_levels, key=key)
+
+    def _pick_open_level(self, theta_val: float) -> int:
+        return min(self._open_levels, key=lambda lvl: abs(theta_val - lvl))
+
+    def _select_open_item(
+        self,
+        domain: str,
+        preferred_level: int,
+        st: PolicyState,
+        *,
+        peek: bool = False,
+        allow_variant_reuse: bool = False,
+    ) -> Tuple[Optional[object], Optional[int]]:
+        for lvl in self._open_level_order(preferred_level):
+            pool = self._open_index.get(domain, {}).get(lvl, [])
+            options = [it for it in pool if self._is_unseen(it, st)]
+            if allow_variant_reuse and not options:
+                options = [it for it in pool if getattr(it, "id", "") not in st.asked]
+            if options:
+                item = options[0] if peek else self.rng.choice(options)
+                if not peek:
+                    setattr(item, "_open_target_level", preferred_level)
+                    setattr(item, "_open_served_level", lvl)
+                return item, lvl
+        return None, None
+
+    def _open_candidates(
+        self, st: PolicyState, obj_min: int
+    ) -> List[Tuple[str, object, float, int, int, int]]:
+        if self.run_type != "long" or not OPEN_ENABLED_LONG:
+            return []
+
+        force_open = (
+            STAGING_PROFILE
+            and TEST_MODE
+            and TEST_OPEN_FULL
+            and OPEN_RESERVE_FORCE
+        )
+
+        if any(st.hist.get(d, DomainHistory()).obj_count < obj_min for d in DOMAINS):
+            return []
+
+        if st.last_item_type not in ("MCQ", "SJT") and not force_open:
+            return []
+
+        candidates: List[Tuple[str, object, float, int, int, int]] = []
+        debug_updates: Optional[Dict[str, Optional[str]]] = (
+            {d: None for d in DOMAINS} if OPEN_DEBUG_REASON else None
+        )
+        for domain in DOMAINS:
+            hist = st.hist.get(domain, DomainHistory())
+            if hist.open_count >= 2:
+                if debug_updates is not None:
+                    debug_updates[domain] = None
+                continue
+
+            se_val = st.se.get(domain, 1.0)
+            theta_val = st.theta.get(domain, 0.0)
+            target_level: Optional[int] = None
+            eligible = False
+            reason: Optional[str] = None
+            fallback_used = False
+
+            if force_open:
+                open_needed = max(0, 2 - hist.open_count)
+                steps_left = max(GLOBAL_STEP_CAP - st.step, 0)
+                if open_needed > 0 and steps_left >= open_needed:
+                    eligible = True
+                    target_level = self._pick_open_level(theta_val)
+                    reason = "test_force"
+                else:
+                    if debug_updates is not None:
+                        debug_updates[domain] = (
+                            None if open_needed <= 0 else "test_reserve_short"
+                        )
+                    if open_needed <= 0:
+                        continue
+                    continue
+            else:
+                if hist.open_count == 0:
+                    gate_ok = (
+                        hist.obj_count >= OPEN_GATE1_MIN_OBJ
+                        and se_val <= OPEN_GATE1_SE_MAX
+                    )
+                    if gate_ok:
+                        eligible = True
+                        target_level = self._pick_open_level(theta_val)
+                    else:
+                        if hist.obj_count < OPEN_GATE1_MIN_OBJ:
+                            reason = "obj_lt_gate1"
+                        elif se_val > OPEN_GATE1_SE_MAX:
+                            reason = "se_too_high"
+                        else:
+                            reason = "gating"
+                        fallback_used = (
+                            self.run_type == "long"
+                            and hist.obj_count >= OPEN_FALLBACK_AFTER_OBJ
+                            and getattr(hist, "b_stable", hist.level) >= OPEN_FALLBACK_MIN_STABLE
+                        )
+                        if fallback_used:
+                            eligible = True
+                            target_level = self._pick_open_level(theta_val)
+                            reason = "fallback_obj"
+                        else:
+                            if debug_updates is not None:
+                                debug_updates[domain] = reason
+                            continue
+                elif hist.open_count == 1:
+                    if hist.obj_count < OPEN_GATE1_MIN_OBJ:
+                        reason = "obj_lt_gate2"
+                    elif se_val > OPEN_GATE2_SE_MAX:
+                        reason = "se_too_high"
+                    elif not hist.open_contrib:
+                        reason = "open1_missing"
+                    else:
+                        first = hist.open_contrib[0]
+                        if first.get("ignored") is not None:
+                            reason = "open1_ignored"
+                        else:
+                            r1 = float(first.get("r", 0.0))
+                            if r1 < OPEN_GATE2_MIN_R1:
+                                reason = "r1_too_low"
+                            else:
+                                b1 = int(first.get("b", 0))
+                                mu1 = float(first.get("mu", 0.5))
+                                denom = max(mu1 * (1.0 - mu1), 1e-6)
+                                z1 = (r1 - mu1) / math.sqrt(denom)
+                                target_level = b1
+                                recent = hist.recent_window[-4:]
+                                last_two = recent[-2:] if len(recent) >= 2 else []
+                                has_miss = any(not x for x in hist.recent_window[-3:])
+                                if len(last_two) == 2 and all(last_two) and z1 >= OPEN_Z_SHIFT:
+                                    target_level = min(b1 + 1, self._open_levels[-1])
+                                elif has_miss and z1 <= -OPEN_Z_SHIFT:
+                                    target_level = max(b1 - 1, self._open_levels[0])
+                                eligible = True
+                    if not eligible:
+                        fallback_used = (
+                            self.run_type == "long"
+                            and hist.obj_count >= OPEN_FALLBACK_AFTER_OBJ + 2
+                            and getattr(hist, "b_stable", hist.level) >= OPEN_FALLBACK_MIN_STABLE
+                        )
+                        if fallback_used:
+                            eligible = True
+                            target_level = self._pick_open_level(theta_val)
+                            reason = "fallback_obj2"
+                    if not eligible:
+                        if debug_updates is not None:
+                            debug_updates[domain] = reason or "gating"
+                        continue
+                else:
+                    if debug_updates is not None:
+                        debug_updates[domain] = None
+                    continue
+
+            if target_level is None:
+                if debug_updates is not None and not fallback_used:
+                    debug_updates[domain] = reason or "gating"
+                continue
+
+            item, served_level = self._select_open_item(
+                domain,
+                int(target_level),
+                st,
+                peek=True,
+                allow_variant_reuse=force_open,
+            )
+            if item is None:
+                if debug_updates is not None:
+                    debug_updates[domain] = "no_items"
+                continue
+
+            if debug_updates is not None:
+                debug_updates[domain] = None if not fallback_used else reason
+
+            candidates.append(
+                (
+                    domain,
+                    item,
+                    se_val,
+                    hist.open_count,
+                    int(target_level),
+                    int(served_level if served_level is not None else target_level),
+                )
+            )
+
+        if debug_updates is not None:
+            self._open_debug.update(debug_updates)
+
+        return candidates
+
+    def _open_candidate_exists(self, st: PolicyState, obj_min: int) -> bool:
+        return bool(self._open_candidates(st, obj_min))
+
+    def _maybe_serve_open(
+        self, st: PolicyState, obj_min: int, sr_needed: int
+    ) -> Optional[object]:
+        force_open = (
+            self.run_type == "long"
+            and OPEN_ENABLED_LONG
+            and STAGING_PROFILE
+            and TEST_MODE
+            and TEST_OPEN_FULL
+            and OPEN_RESERVE_FORCE
+        )
+        if sr_needed > 0 and not force_open:
+            return None
+
+        candidates = self._open_candidates(st, obj_min)
+        if not candidates:
+            return None
+
+        def key(entry: Tuple[str, object, float, int, int, int]) -> Tuple:
+            dom, _, se_val, open_count, _, _ = entry
+            rotation = 0 if st.last_domain_id == dom else -1
+            return (-se_val, open_count, rotation, self._domain_index[dom])
+
+        domain, _, _, _, target_level, _ = sorted(candidates, key=key)[0]
+        item, served_level = self._select_open_item(
+            domain,
+            target_level,
+            st,
+            allow_variant_reuse=force_open,
+        )
+        if item is None:
+            return None
+        if served_level is None:
+            served_level = target_level
+        setattr(item, "_open_target_level", target_level)
+        setattr(item, "_open_served_level", served_level)
+        return item
+
+    def _serve_short_extra(self, st: PolicyState):
+        extras_total = sum(
+            max(0, st.hist.get(dom, DomainHistory()).obj_count - SHORT_OBJ_MIN)
+            for dom in DOMAINS
+        )
+        if extras_total >= SHORT_EXTRA_TOTAL:
+            return None
+
+        eligible = [
+            d for d in DOMAINS if st.hist.get(d, DomainHistory()).obj_count < SHORT_OBJ_MAX
+        ]
+        if not eligible:
+            return None
+
+        if self._short_extra_domains is None:
+            ordered = self._sort_candidates(eligible, st)
+            self._short_extra_domains = ordered[:4]
+
+        if not self._short_extra_domains:
+            return None
+
+        for dom in self._short_extra_domains:
+            if dom not in eligible:
+                continue
+            hist = st.hist.get(dom, DomainHistory())
+            extras_for_dom = max(0, hist.obj_count - SHORT_OBJ_MIN)
+            if extras_for_dom >= 2:
+                continue
+            if hist.obj_count >= SHORT_OBJ_MAX:
+                continue
+            item = self._objective_item(dom, st)
+            if item is not None:
+                return item
+
+        return None
+
+    def _next_item_short(self, st: PolicyState):
+        cap = CAP_SHORT
+        steps_left = max(cap - st.step, 0)
+        if steps_left <= 0:
+            return None
+
+        minima_domains = [
+            d for d in DOMAINS if st.hist.get(d, DomainHistory()).obj_count < SHORT_OBJ_MIN
+        ]
+        if minima_domains:
+            domains = self._sort_candidates(minima_domains, st)
+            item = self._serve_objective(domains, st)
+            if item is not None:
+                self._last_pick_was_sr = False
+            return item
+
+        sr_remaining = sum(
+            max(0, SHORT_SR_PER_DOMAIN - st.hist.get(d, DomainHistory()).sr_count)
+            for d in DOMAINS
+        )
+        sr_only = sr_remaining > 0 and steps_left <= sr_remaining
+        if sr_remaining > 0:
+            sr_domain = self._sr_domain(st, SHORT_OBJ_MIN, SHORT_SR_PER_DOMAIN)
+            if sr_domain is not None and (sr_only or not self._last_pick_was_sr):
+                item = self._pick_sr_item(sr_domain, st)
+                if item is not None:
+                    setattr(item, "_target_level", None)
+                    setattr(item, "_served_level", None)
+                    self._last_pick_was_sr = True
+                    return item
+
+        item = self._serve_short_extra(st)
+        if item is not None:
+            self._last_pick_was_sr = False
+            return item
+
+        return None
+
+    def _is_unseen(self, item, st: PolicyState) -> bool:
+        iid = getattr(item, "id", "")
+        if iid in st.asked:
+            return False
+        vg = getattr(item, "variant_group", None)
+        if vg and vg in st.seen_variant_groups:
+            return False
+        return True
+
+    def _objective_item(self, domain: str, st: PolicyState, *, peek: bool = False) -> Optional:
+        hist = st.hist.get(domain, DomainHistory())
+        base_level = hist.level
+        if self.run_type == "short":
+            base_level = max(self._short_min, min(self._short_max, base_level))
+            order = self._short_level_order(base_level)
+        else:
+            order = self._level_order(base_level)
+
+        for lvl in order:
+            if self.run_type == "short" and (lvl < self._short_min or lvl > self._short_max):
+                continue
+            pool = self._obj_index.get(domain, {}).get(lvl, [])
+            options = [it for it in pool if self._is_unseen(it, st)]
+            if options:
+                item = options[0] if peek else self.rng.choice(options)
+                if not peek:
+                    setattr(item, "_target_level", base_level)
+                    setattr(item, "_served_level", lvl)
+                return item
+        return None
+
+    def _objective_available(self, domain: str, st: PolicyState) -> bool:
+        return self._objective_item(domain, st, peek=True) is not None
+
+    def _serve_objective(self, domains: List[str], st: PolicyState):
+        for dom in domains:
+            item = self._objective_item(dom, st)
+            if item is not None:
+                return item
+        return None
+
+    def _fallback_objective(self, st: PolicyState):
+        level_iter = self._short_levels if self.run_type == "short" else range(LEVEL_MIN, LEVEL_MAX + 1)
+        for dom in DOMAINS:
+            for lvl in level_iter:
+                if self.run_type == "short" and (lvl < self._short_min or lvl > self._short_max):
+                    continue
+                pool = self._obj_index.get(dom, {}).get(lvl, [])
+                options = [it for it in pool if self._is_unseen(it, st)]
+                if options:
+                    item = self.rng.choice(options)
+                    setattr(item, "_target_level", st.hist.get(dom, DomainHistory()).level)
+                    setattr(item, "_served_level", lvl)
+                    return item
+        return None
+
+    def _sr_available(self, domain: str, st: PolicyState) -> bool:
+        for it in self._sr_index.get(domain, []):
+            if self._is_unseen(it, st):
+                return True
+        return False
+
+    def _sr_domain(self, st: PolicyState, obj_min: int, sr_required: int) -> Optional[str]:
+        domains = [
+            d
+            for d in DOMAINS
+            if st.hist.get(d, DomainHistory()).obj_count >= obj_min
+            and st.hist.get(d, DomainHistory()).sr_count < sr_required
+            and self._sr_available(d, st)
+        ]
+        if not domains:
+            return None
+
+        def key(dom: str) -> tuple:
+            sr_count = st.hist.get(dom, DomainHistory()).sr_count
+            rotation = 0 if st.last_domain_id == dom else -1
+            return (sr_count, rotation, self._domain_index[dom])
+
+        return sorted(domains, key=key)[0]
+
+    def _pick_sr_item(self, domain: str, st: PolicyState):
+        pool = [it for it in self._sr_index.get(domain, []) if self._is_unseen(it, st)]
+        if not pool:
+            return None
+        return self.rng.choice(pool)
+
+
+def _simulate_run(run_type: str, pattern: List[Tuple[int, int]]) -> List[int]:
+    """Developer helper: returns level trajectory for synthetic answers."""
+
+    from .engine import DomainState, _apply_objective_step
+
+    ds = DomainState(level=-1)
+    levels = [ds.level]
+    for level, correct in pattern:
+        _apply_objective_step(ds, level, bool(correct), run_type, target_level=ds.level)
+        levels.append(ds.level)
+    return levels
+
+
+def _dev_check_sr_scheduling() -> None:
+    from .types import Item
+
+    items: List[Item] = []
+    for dom in DOMAINS:
+        for lvl in range(LEVEL_MIN, LEVEL_MAX + 1):
+            items.append(
+                Item(
+                    id=f"{dom}_mcq_{lvl:+d}",
+                    domain=dom,
+                    type="MCQ",
+                    text="stub",
+                    options=["A", "B"],
+                    correct=0,
+                    difficulty=lvl,
+                )
+            )
+        for idx in range(SR_PER_DOMAIN_LONG):
+            items.append(
+                Item(
+                    id=f"{dom}_sr_{idx}",
+                    domain=dom,
+                    type="SR",
+                    text="stub",
+                    options=["1", "2", "3", "4", "5"],
+                )
+            )
+
+    policy = QuestionPolicy(items, "long")
+    obj_min = OBJ_MIN_LONG
+    sr_required = SR_PER_DOMAIN_LONG
+
+    hist = {dom: DomainHistory(obj_count=obj_min - 1, sr_count=0) for dom in DOMAINS}
+    base_state = PolicyState(
+        run_type="long",
+        theta={dom: 0.0 for dom in DOMAINS},
+        se={dom: 1.0 for dom in DOMAINS},
+        asked=set(),
+        seen_variant_groups=set(),
+        step=0,
+        hist=hist,
+        info_history=[],
+        mirrored_domains_planned=set(),
+        last_domain_id=None,
+        last_item_type="MCQ",
+    )
+
+    assert (
+        policy._sr_domain(base_state, obj_min, sr_required) is None
+    ), "SR should not schedule before objective minima"
+
+    first_dom = DOMAINS[0]
+    hist[first_dom].obj_count = obj_min
+    sr_dom = policy._sr_domain(base_state, obj_min, sr_required)
+    assert sr_dom == first_dom, "SR should unlock once minima met"
+
+    hist[first_dom].sr_count = sr_required
+    assert (
+        policy._sr_domain(base_state, obj_min, sr_required) is None
+    ), "SR should respect per-domain cap"
+
+    print("[dev] SR scheduling respects objective minima and per-domain caps.")
+
+
+if __name__ == "__main__":
+    short_path = [
+        (-1, 1), (-1, 1),
+        (0, 1), (0, 1),
+        (1, 1), (1, 0), (1, 1), (1, 1),
+        (2, 1),
+    ]
+    long_path = [
+        (-1, 1), (-1, 1), (-1, 1), (-1, 0),
+        (0, 1), (0, 1), (0, 1), (0, 0),
+        (1, 1), (1, 1), (1, 1), (1, 0),
+        (2, 1),
+    ]
+    _dev_check_sr_scheduling()
+    print("Short ladder levels:", _simulate_run("short", short_path))
+    print("Long ladder levels:", _simulate_run("long", long_path))

--- a/skill_core/rasch.py
+++ b/skill_core/rasch.py
@@ -1,0 +1,139 @@
+"""Rasch 1PL utilities used by the adaptive engine.
+
+This module provides a minimal set of helpers for computing logistic
+probabilities, Fisher information, and a damped MAP (Newton) update for the
+person ability parameter.  Functions are intentionally lightweight so that
+future policy tweaks can reuse them from both the API runtime and developer
+CLI tools.
+"""
+from __future__ import annotations
+
+import math
+from typing import List, Tuple
+
+__all__ = [
+    "sigma",
+    "rasch_p",
+    "item_info",
+    "map_update",
+    "se_from_info",
+]
+
+_EPS = 1e-6
+
+
+def sigma(x: float) -> float:
+    """Return the logistic function ``σ(x) = 1 / (1 + e^{−x})``.
+
+    The implementation guards against overflow for large negative inputs by
+    handling the positive and negative halves of the real line separately.
+    """
+
+    if x >= 0:
+        z = math.exp(-x)
+        return 1.0 / (1.0 + z)
+    z = math.exp(x)
+    return z / (1.0 + z)
+
+
+def rasch_p(theta: float, b: float) -> float:
+    """Compute the Rasch 1PL probability of a correct answer.
+
+    Parameters
+    ----------
+    theta: float
+        Current estimate of the learner ability.
+    b: float
+        Item difficulty parameter.
+
+    Returns
+    -------
+    float
+        ``σ(theta − b)``
+    """
+
+    return sigma(theta - b)
+
+
+def item_info(theta: float, b: float, a: float = 1.0) -> float:
+    """Fisher information contributed by a single 1PL item.
+
+    The Rasch formulation treats discrimination ``a`` as 1.0, but the
+    parameter is left explicit for future flexibility.
+    """
+
+    p = rasch_p(theta, b)
+    info = (a * a) * p * (1.0 - p)
+    return max(info, 0.0)
+
+
+def map_update(
+    theta: float,
+    b: float,
+    correct: bool,
+    a: float = 1.0,
+    prior_var: float = 1.0,
+    eta: float = 1.0,
+) -> float:
+    """Perform a damped Newton/MAP update for the Rasch person ability.
+
+    Parameters mirror the pseudocode from the task description.  ``prior_var``
+    provides Gaussian shrinkage towards zero while ``eta`` can be used to
+    throttle the step size.
+    """
+
+    p = rasch_p(theta, b)
+    grad = ((1.0 if correct else 0.0) - p) * a
+    info = (a * a) * p * (1.0 - p) + (1.0 / max(prior_var, _EPS))
+    step = eta * grad / max(info, _EPS)
+    return float(theta + step)
+
+
+def se_from_info(info_total: float) -> float:
+    """Convert accumulated Fisher information into a standard error."""
+
+    return 1.0 / math.sqrt(max(info_total, _EPS))
+
+
+def _demo_sequence() -> Tuple[List[float], List[float]]:
+    """Run a developer demo with synthetic data.
+
+    Returns the history of ``theta`` and ``se`` for downstream assertions.
+    """
+
+    theta_hist: List[float] = []
+    se_hist: List[float] = []
+    theta = 0.0
+    info_total = 1.0
+    seq_b = [-1, -1, 0, 0, +1, +1, +1, +2]
+    seq_correct = [1, 1, 1, 0, 1, 1, 0, 1]
+
+    print("step | b | correct | theta    | info_tot |   SE")
+    for idx, (b, correct) in enumerate(zip(seq_b, seq_correct), start=1):
+        theta_new = map_update(theta, b, bool(correct))
+        info_i = item_info(theta_new, b)
+        info_total = max(info_total + info_i, _EPS)
+        se = se_from_info(info_total)
+        theta = theta_new
+
+        theta_hist.append(theta)
+        se_hist.append(se)
+        print(f" {idx:2d}  | {b:+d} |   {correct:d}     | {theta:7.4f} | {info_total:8.4f} | {se:5.4f}")
+
+    if theta_hist:
+        assert theta_hist[-1] > theta_hist[0] - 1e-6, "θ should increase overall"
+    for prev, cur in zip(se_hist, se_hist[1:]):
+        assert cur <= prev + 1e-6, "SE should be non-increasing"
+    return theta_hist, se_hist
+
+
+if __name__ == "__main__":  # pragma: no cover - developer utility
+    # Inline sanity checks for quick confidence during refactors.
+    assert abs(sigma(0.0) - 0.5) < 1e-9
+    assert rasch_p(1.0, 0.0) > 0.5
+    assert abs(item_info(0.0, 0.0) - 0.25) < 1e-6
+    theta_hist, se_hist = _demo_sequence()
+    print(f"Final θ: {theta_hist[-1]:.4f}, Final SE: {se_hist[-1]:.4f}")
+    print(
+        "Rasch/SE enabled: domain state now includes {theta, se, info_total, level, b_peak, b_stable} and updates on OBJ answers."
+    )

--- a/skill_core/report_html.py
+++ b/skill_core/report_html.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 from typing import Dict, Any, List
 
+from .config import AUDIT_EXPORT_ENABLED, SHORT_TIER_CAP
+
 def _row(d: Dict[str, Any]) -> str:
     n = d.get('n', (d.get('asked_obj',0)+d.get('asked_open',0)))
     cap = d.get('cap', '')
@@ -8,16 +10,191 @@ def _row(d: Dict[str, Any]) -> str:
     return f"<tr><td>{d.get('domain')}{cap_mark}</td><td>{d.get('norm_score'):.1f}</td><td>{d.get('se'):.2f}</td><td>{n}</td></tr>"
 
 def _row_breakdown(d: Dict[str, Any]) -> str:
-    return f"<tr><td>{d.get('domain')}</td><td>{d.get('obj_pct','-')}</td><td>{d.get('open_pct','-')}</td><td>{d.get('sr_pct','-')}</td></tr>"
+    return f"<tr><td>{d.get('domain')}</td><td>{d.get('obj_pct','-')}</td><td>{d.get('open_pct','-')}</td></tr>"
 
 def export_report_html(result: Dict[str, Any], path: str) -> None:
     doms_raw = result.get("domain_scores", [])
     doms: List[Dict[str, Any]] = [dd if isinstance(dd, dict) else dd.__dict__ for dd in doms_raw]
     summ = result.get("summary", {}) or {}
+    meta = result.get("meta", {}) or {}
     hidden = result.get("hidden_skills", []) or []
     overall = float(summ.get("mean", 0.0))
     rows = "\n".join(_row(d) for d in doms)
     rows2 = "\n".join(_row_breakdown(d) for d in doms)
+
+    run_type = str(result.get("run_type") or (result.get("meta") or {}).get("run") or "").lower()
+
+    run_summary_html = ""
+    cap_txt = str(summ.get("cap") or "").strip()
+    steps_used = summ.get("steps_used")
+    sr_used = summ.get("sr_used")
+    open_used = summ.get("open_used")
+    summary_bits: List[str] = []
+    if cap_txt:
+        summary_bits.append(f"steps {cap_txt}")
+    if isinstance(sr_used, (int, float)):
+        summary_bits.append(f"SR used {int(sr_used)}")
+    if isinstance(open_used, (int, float)):
+        summary_bits.append(f"OPEN used {int(open_used)}")
+    if summary_bits:
+        run_summary_html = f"<p><b>Run summary:</b> {' · '.join(summary_bits)}</p>"
+
+    tier_notes: List[str] = []
+    if run_type == 'short':
+        tier_notes.append(
+            '<li>Short run extras limited to top four domains (max two each)</li>'
+        )
+    for d in doms:
+        tier_val = str(d.get('tier') or '').upper()
+        domain = d.get('domain') or 'Domain'
+        gate = d.get('god_gate') or {}
+        if run_type == 'short' and d.get('short_cap_applied'):
+            tier_notes.append(f"<li>{domain}: Short run capped at {SHORT_TIER_CAP}</li>")
+
+        if tier_val == 'GOD':
+            hints = []
+            if isinstance(gate, dict):
+                hints.append('SE ok' if gate.get('se_ok') else 'SE high')
+                hints.append('L2 acc ok' if gate.get('l2_acc_ok') else 'L2 acc low')
+                hints.append('OPEN ok' if gate.get('open_ok') else 'OPEN gate')
+            tier_notes.append(
+                f"<li>{domain}: GOD gate passed ({', '.join(hints)})</li>"
+            )
+        elif run_type == 'long' and isinstance(gate, dict) and gate.get('status') == 'near' and gate.get('norm_ok'):
+            misses: List[str] = []
+            if not gate.get('se_ok'):
+                misses.append('SE high')
+            if not gate.get('l2_acc_ok'):
+                misses.append('L2 accuracy low')
+            if not gate.get('open_ok'):
+                misses.append('Open count low')
+            if not gate.get('r1_ok') or not gate.get('r2_ok'):
+                misses.append('Open ratings low')
+            if not gate.get('level_ok') or not gate.get('l2_seen_ok'):
+                misses.append('L2 volume low')
+            if misses:
+                tier_notes.append(
+                    f"<li>{domain}: Near-SS; GOD gate not met ({', '.join(misses)})</li>"
+                )
+
+    tier_notes_html = ''
+    if tier_notes:
+        tier_notes_html = '<div class="tier-notes"><h3>Tier notes</h3><ul>' + ''.join(tier_notes) + '</ul></div>'
+
+    incomplete_html = ""
+    if meta.get("incomplete") and meta.get("incomplete_reason") == "CAP_BEFORE_MINIMA":
+        shortfalls = meta.get("shortfalls") or {}
+        if isinstance(shortfalls, dict) and shortfalls:
+            items: List[str] = []
+            for dom, val in shortfalls.items():
+                try:
+                    needed = int(val)
+                except Exception:
+                    needed = val
+                items.append(f"<li>{dom}: needs {needed} more objective item(s)</li>")
+            if items:
+                incomplete_html = (
+                    "<div class=\"banner warning\">"
+                    "Run hit step cap before completing minimum objectives"
+                    f"<ul>{''.join(items)}</ul>"
+                    "</div>"
+                )
+
+    plan_entries = result.get("plan") or []
+    plan_section = ""
+    if plan_entries and run_type == "long":
+        blocks: List[str] = []
+        for entry in plan_entries:
+            if not isinstance(entry, dict):
+                continue
+            goals = entry.get("goals") or []
+            items: List[str] = []
+            for goal in goals:
+                if not isinstance(goal, dict):
+                    continue
+                g_type = str(goal.get("type") or "Goal").capitalize()
+                text = goal.get("text") or ""
+                measure = goal.get("measure")
+                tag = goal.get("tag")
+                extras = []
+                if tag:
+                    extras.append(f"focus: {tag}")
+                if measure:
+                    extras.append(str(measure))
+                extra_txt = f" <span>({' · '.join(extras)})</span>" if extras else ""
+                items.append(f"<li><b>{g_type}</b>: {text}{extra_txt}</li>")
+            lvl = entry.get("level") or "0"
+            blocks.append(
+                '<div>'
+                + f"<h4>{entry.get('domain')} (level {lvl})</h4>"
+                + f"<ul>{''.join(items)}</ul>"
+                + '</div>'
+            )
+        if blocks:
+            plan_section = '<h3>Improvement Plan</h3>' + ''.join(blocks)
+
+    open_sections: List[str] = []
+    for d in doms:
+        contribs = d.get('open_contrib') or []
+        reason_txt = str(d.get('open_debug_reason') or '').strip()
+        open_count = int(d.get('open_count', 0) or 0)
+        if not contribs:
+            if open_count == 0 and reason_txt:
+                open_sections.append(
+                    '<div>'
+                    + f"<h4>{d.get('domain')}</h4>"
+                    + f"<p>OPEN not scheduled: {reason_txt}</p>"
+                    + '</div>'
+                )
+            continue
+        lines: List[str] = []
+        for entry in contribs:
+            try:
+                b = int(entry.get('b', 0))
+            except Exception:
+                b = 0
+            r = float(entry.get('r', 0.0) or 0.0)
+            mu = float(entry.get('mu', 0.0) or 0.0)
+            dtheta = float(entry.get('dtheta', 0.0) or 0.0)
+            scaled = ' (capped)' if entry.get('scaled') else ''
+            ignored = entry.get('ignored')
+            note = f" (ignored: {ignored})" if ignored else ''
+            lines.append(
+                f"<li>OPEN @ {b:+d}: r={r:.2f} vs expected mu={mu:.2f} -> delta_theta={dtheta:+.3f}{scaled}{note}</li>"
+            )
+        theta_val = float(d.get('theta', 0.0) or 0.0)
+        se_val = float(d.get('se', 0.0) or 0.0)
+        open_sections.append(
+            '<div>'
+            + f"<h4>{d.get('domain')}</h4>"
+            + f"<p>OPEN count: {int(d.get('open_count', 0) or 0)} | theta={theta_val:.3f} | SE={se_val:.3f}</p>"
+            + f"<ul>{''.join(lines)}</ul>"
+            + '</div>'
+        )
+
+    open_summary = ''
+    if open_sections:
+        open_summary = '<h3>OPEN contributions</h3>' + ''.join(open_sections)
+
+    reliability_sections: List[str] = []
+    reliability_flagged = False
+    for d in doms:
+        rel = d.get('reliability') or {}
+        mirror_ok = bool(rel.get('sr_mirror_ok', True))
+        trap_count = int(rel.get('trap_count', 0) or 0)
+        mirror_txt = 'OK' if mirror_ok else 'Needs review'
+        reliability_sections.append(
+            '<div>'
+            + f"<h4>{d.get('domain')}</h4>"
+            + f"<p>Mirror consistency: {mirror_txt} · Trap flags: {trap_count}</p>"
+            + '</div>'
+        )
+        if not mirror_ok or trap_count > 0:
+            reliability_flagged = True
+
+    reliability_html = ''
+    if reliability_sections:
+        reliability_html = '<h3>Self-report &amp; reliability</h3>' + ''.join(reliability_sections)
 
     # Undervalued = hidden skills list intersects with domain rows
     uv = []
@@ -34,6 +211,18 @@ def export_report_html(result: Dict[str, Any], path: str) -> None:
               "<tbody>" + "\n".join(uv_rows) + "</tbody></table>"]
 
     foot = "<p><i>* capped due to no OPEN: ≤80.</i></p>"
+
+    audit_links = ""
+    if AUDIT_EXPORT_ENABLED:
+        report_id = result.get("reportId") or meta.get("reportId")
+        if report_id:
+            rid = str(report_id)
+            audit_links = (
+                "<p class=\"audit-links\">"
+                f"<a href=\"/results/{rid}/audit.json\">Download audit (JSON)</a> · "
+                f"<a href=\"/results/{rid}/audit.csv\">Download audit (CSV)</a>"
+                "</p>"
+            )
 
     cats = f"""
     <h3>Performance categories</h3>
@@ -54,6 +243,8 @@ def export_report_html(result: Dict[str, Any], path: str) -> None:
  .wrap{{max-width:960px;margin:40px auto;padding:0 16px}}
  h1{{margin:0 0 16px}}
  .overall{{font-size:1.1rem;margin:8px 0 16px}}
+ .banner{{padding:12px 16px;border-radius:6px;margin:16px 0}}
+ .banner.warning{{background:#ffe7d9;border:1px solid #f5a623;color:#7a2d00}}
  table{{border-collapse:collapse;width:100%}}
  th,td{{text-align:left}}
 </style>
@@ -62,24 +253,35 @@ def export_report_html(result: Dict[str, Any], path: str) -> None:
 <div class="wrap">
   <h1>Skill Report</h1>
   <div class="overall"><b>Overall:</b> {overall:.1f}</div>
+  {run_summary_html}
+  {incomplete_html}
 
   <table border='1' cellpadding='6' cellspacing='0'>
     <thead><tr><th>Domain</th><th>Score</th><th>SE</th><th>N</th></tr></thead>
     <tbody>{rows}</tbody>
   </table>
   {foot}
+  {tier_notes_html}
 
   <h3>Component breakdown (0–100)</h3>
   <table border='1' cellpadding='6' cellspacing='0'>
-    <thead><tr><th>Domain</th><th>OBJ%</th><th>OPEN%</th><th>SR%</th></tr></thead>
+    <thead><tr><th>Domain</th><th>OBJ%</th><th>OPEN%</th></tr></thead>
     <tbody>{rows2}</tbody>
   </table>
+
+  {plan_section}
+
+  {open_summary}
+
+  {reliability_html}
 
   {''.join(uv) if uv else ''}
 
   {cats}
 
   <p><b>Timing:</b> SR {summ.get('avg_rt_sr',0)}s · MCQ {summ.get('avg_rt_mcq',0)}s · SJT {summ.get('avg_rt_sjt',0)}s · OPEN N={summ.get('oe_items',0)}</p>
+  {audit_links}
+  {'<p><b>Reliability:</b> Some self-report answers need review.</p>' if reliability_flagged else ''}
 </div>
 </body>
 </html>"""

--- a/skill_core/smoke.py
+++ b/skill_core/smoke.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import List
+
+from .config import DEBUG_SEED, TRACE_FIELDS, DEBUG_TRACE, STAGING_PROFILE
+from .engine import AdaptiveSession
+from .plan import generate_plan
+from .question_bank import DOMAINS
+from .types import Answer, Item
+
+
+def _maybe_enable_trace() -> None:
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+    if DEBUG_TRACE:
+        logging.getLogger("skill_core.engine").setLevel(logging.INFO)
+
+
+def _synthetic_bank() -> List[Item]:
+    items: List[Item] = []
+    for domain in DOMAINS:
+        for level in range(-2, 3):
+            for idx in range(3):
+                items.append(
+                    Item(
+                        id=f"smoke_{domain}_mcq_{level}_{idx}",
+                        domain=domain,
+                        type="MCQ",
+                        text=f"{domain} MCQ {level}",
+                        options=["A", "B", "C", "D"],
+                        correct=0,
+                        difficulty=level,
+                        variant_group=f"smoke_{domain}_mcq_{level}_{idx}",
+                    )
+                )
+        for idx in range(2):
+            items.append(
+                Item(
+                    id=f"smoke_{domain}_sr_{idx}",
+                    domain=domain,
+                    type="SR",
+                    text=f"Rate your {domain} confidence",
+                    options=["0", "1", "2", "3", "4"],
+                    difficulty=0,
+                    variant_group=f"smoke_{domain}_sr_{idx}",
+                )
+            )
+        for level in (-1, 0, 1):
+            items.append(
+                Item(
+                    id=f"smoke_{domain}_open_{level}",
+                    domain=domain,
+                    type="OPEN",
+                    text=f"Describe a {domain} challenge",
+                    difficulty=level,
+                    variant_group=f"smoke_{domain}_open_{level}",
+                )
+            )
+    return items
+
+
+def _auto_answer(item: Item) -> Answer:
+    if item.type == "MCQ":
+        return Answer(item_id=item.id, value=item.correct or 0, rt_sec=18.0)
+    if item.type == "SJT":
+        return Answer(item_id=item.id, value=0, rt_sec=22.0)
+    if item.type == "SR":
+        return Answer(item_id=item.id, value=3, rt_sec=5.0)
+    words = "practice".split()
+    open_text = " ".join(words * 80)
+    return Answer(item_id=item.id, value=open_text, rt_sec=120.0)
+
+
+def _trace_fields() -> str:
+    return ", ".join(TRACE_FIELDS)
+
+
+def run_smoke_session() -> None:
+    _maybe_enable_trace()
+
+    from skill_core import engine as eng
+
+    bank = _synthetic_bank()
+    eng.load_bank = lambda: list(bank)
+
+    session = AdaptiveSession("long")
+    logging.info("Starting synthetic long run with DEBUG_SEED=%s", DEBUG_SEED)
+    logging.info("Trace fields: %s", _trace_fields())
+
+    while True:
+        item = session.next_item()
+        if item is None:
+            break
+        answer = _auto_answer(item)
+        session.answer_current(answer)
+
+    result = session.finalize()
+    payload = json.loads(json.dumps(result, default=lambda o: getattr(o, "__dict__", o)))
+    cfg = {}
+    plan = generate_plan(payload, cfg)
+
+    if STAGING_PROFILE:
+        meta = payload.get("meta", {}) or {}
+        shortfalls = meta.get("shortfalls") or {}
+        for domain in DOMAINS:
+            state = session.state.domains.get(domain)
+            theta = getattr(state, "theta", 0.0)
+            se = getattr(state, "se", 0.0)
+            b_stable = getattr(state, "b_stable", 0)
+            obj_count = getattr(state, "obj_count", 0)
+            open_count = getattr(state, "open_count", 0)
+            print(f"{domain}: θ={theta:.2f} SE={se:.2f} b_stable={b_stable:+d} OBJ={obj_count} OPEN={open_count}")
+        steps_total = meta.get("steps_total", 0)
+        cap_limit = meta.get("cap", 0)
+        total_sr = sum(getattr(st, "sr_count", 0) for st in session.state.domains.values())
+        total_open = sum(getattr(st, "open_count", 0) for st in session.state.domains.values())
+        minima_unmet = sum(shortfalls.values()) > 0 if isinstance(shortfalls, dict) else False
+        print(
+            f"cap={steps_total}/{cap_limit} minima_unmet={minima_unmet} sr_used={total_sr} open_used={total_open}"
+        )
+        return
+
+    logging.info(
+        "Run complete: steps=%s cap=%s",
+        payload.get("meta", {}).get("steps_total"),
+        payload.get("meta", {}).get("cap"),
+    )
+
+    for domain_score in payload.get("domain_scores", []):
+        logging.info(
+            "Domain %s: theta=%.3f se=%.3f level=%s stable=%s obj=%s open=%s",
+            domain_score.get("domain"),
+            float(domain_score.get("theta", 0.0)),
+            float(domain_score.get("se", 0.0)),
+            domain_score.get("level"),
+            domain_score.get("b_stable"),
+            domain_score.get("obj_count"),
+            domain_score.get("open_count"),
+        )
+        logging.info(
+            "  items_by_level=%s",
+            domain_score.get("items_by_level"),
+        )
+        contribs = domain_score.get("open_contrib") or []
+        for entry in contribs:
+            logging.info(
+                "  OPEN @%s r=%.2f mu=%.2f dtheta=%.3f%s",
+                entry.get("b"),
+                float(entry.get("r", 0.0)),
+                float(entry.get("mu", 0.0)),
+                float(entry.get("dtheta", 0.0)),
+                " (scaled)" if entry.get("scaled") else "",
+            )
+
+    logging.info("Plan entries generated: %d", len(plan))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    run_smoke_session()
+

--- a/skill_core/types.py
+++ b/skill_core/types.py
@@ -20,7 +20,13 @@ class Answer:
     item_id: str; value: str; rt_sec: Optional[float] = None
 @dataclass
 class DomainScore:
-    domain: str; theta: float; se: float; norm_score: float; tier: str; rarity: str
+    domain: str
+    theta: float
+    se: float
+    norm_score: float
+    tier: str
+    rarity: str
+    reliability: Optional[Dict[str, object]] = None
 @dataclass
 class HiddenSkill:
     domain: str; confidence: Literal["Low","Medium","High"]; reason: str
@@ -35,3 +41,5 @@ class Result:
     synergy_boost: float
     unique_award: Optional[str] = None
     summary: Dict[str, float] = field(default_factory=dict)
+    plan: List[Dict[str, object]] = field(default_factory=list)
+    audit_events: List[Dict[str, object]] = field(default_factory=list)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+
+from skill_core.question_bank import DOMAINS
+from skill_core.types import Item
+
+
+def build_synthetic_bank(
+    *,
+    domains: list[str] | None = None,
+    mcq_per_level: int = 3,
+    include_sr: bool = True,
+    include_open: bool = True,
+) -> list[Item]:
+    """Create a deterministic synthetic bank for tests and smoke runs."""
+
+    items: list[Item] = []
+    target_domains = domains or list(DOMAINS)
+    for domain in target_domains:
+        for level in range(-2, 3):
+            for idx in range(mcq_per_level):
+                items.append(
+                    Item(
+                        id=f"{domain}_mcq_{level}_{idx}",
+                        domain=domain,
+                        type="MCQ",
+                        text=f"{domain} MCQ {level} #{idx}",
+                        options=["A", "B", "C", "D"],
+                        correct=0,
+                        difficulty=level,
+                        variant_group=f"{domain}_mcq_vg_{level}_{idx}",
+                    )
+                )
+
+        if include_sr:
+            for idx in range(2):
+                items.append(
+                    Item(
+                        id=f"{domain}_sr_{idx}",
+                        domain=domain,
+                        type="SR",
+                        text=f"Rate your {domain} confidence",
+                        options=["0", "1", "2", "3", "4"],
+                        difficulty=0,
+                        variant_group=f"{domain}_sr_vg_{idx}",
+                    )
+                )
+
+        if include_open:
+            for level in (-1, 0, 1):
+                items.append(
+                    Item(
+                        id=f"{domain}_open_{level}",
+                        domain=domain,
+                        type="OPEN",
+                        text=f"Describe a {domain} challenge",
+                        difficulty=level,
+                        variant_group=f"{domain}_open_vg_{level}",
+                    )
+                )
+
+    return items
+
+
+@pytest.fixture
+def synthetic_bank() -> list[Item]:
+    return build_synthetic_bank()
+

--- a/tests/test_api_dev_overrides.py
+++ b/tests/test_api_dev_overrides.py
@@ -1,0 +1,176 @@
+import os
+
+from fastapi.testclient import TestClient
+
+from tests.test_api_flows import _reload_app
+
+
+def _client(tmp_path):
+    os.environ["STAGING_PROFILE"] = "1"
+    storage, app_module = _reload_app(tmp_path)
+    return TestClient(app_module.app)
+
+
+def test_dev_run_god_overrides(tmp_path):
+    client = _client(tmp_path)
+    try:
+        prod = client.get("/dev/run", params={"run": "long", "mode": "pass", "seed": 11})
+        assert prod.status_code == 200
+        prod_payload = prod.json()
+        tiers = prod_payload.get("tiers", [])
+        assert tiers, "expected tiers in prod payload"
+        assert all(tier != "GOD" for tier in tiers)
+        reasons = prod_payload.get("reasons", {})
+        assert isinstance(reasons, dict)
+        for dom, flags in reasons.items():
+            assert set(flags or []) & {"norm_low", "se_high", "open_count_low", "open_rubric_low"}, dom
+
+        staging = client.get(
+            "/dev/run",
+            params={
+                "run": "long",
+                "mode": "pass",
+                "seed": 12,
+                "TEST_MODE": 1,
+                "TEST_GOD_MIN_NORM": 0.0,
+                "TEST_GOD_MAX_SE": 1.0,
+                "TEST_GOD_MIN_L2_SEEN": 0,
+                "TEST_GOD_MIN_L2_ACC": 0.0,
+                "TEST_GOD_MIN_OPEN": 0,
+                "TEST_OPEN_FULL": 1,
+                "TEST_GOD_RUBRIC0": 0.0,
+                "TEST_GOD_RUBRIC1": 0.0,
+            },
+        )
+        assert staging.status_code == 200
+        staging_payload = staging.json()
+        assert staging_payload.get("tiers"), "expected tiers in staging payload"
+        assert all(tier == "GOD" for tier in staging_payload["tiers"])
+        assert staging_payload.get("open_used") == 16
+        staging_reasons = staging_payload.get("reasons", {})
+        assert all(isinstance(v, list) for v in staging_reasons.values())
+        for flags in staging_reasons.values():
+            assert "open_count_low" not in (flags or [])
+            assert "open_rubric_low" not in (flags or [])
+
+        realistic = client.get(
+            "/dev/run",
+            params={
+                "run": "long",
+                "mode": "pass",
+                "seed": 11,
+                "TEST_MODE": 1,
+                "TEST_GOD_MIN_NORM": 9.4,
+                "TEST_GOD_MAX_SE": 0.60,
+                "TEST_GOD_MIN_L2_SEEN": 12,
+                "TEST_GOD_MIN_L2_ACC": 0.80,
+                "TEST_GOD_MIN_OPEN": 16,
+                "TEST_GOD_RUBRIC0": 0.70,
+                "TEST_GOD_RUBRIC1": 0.65,
+                "TEST_OPEN_FULL": 1,
+            },
+        )
+        assert realistic.status_code == 200
+        realistic_payload = realistic.json()
+        assert realistic_payload.get("open_used") == 16
+        assert realistic_payload.get("tiers")
+        assert all(tier == "GOD" for tier in realistic_payload["tiers"])
+        for flags in realistic_payload.get("reasons", {}).values():
+            assert not (flags or [])
+
+        rubric_fail = client.get(
+            "/dev/run",
+            params={
+                "run": "long",
+                "mode": "pass",
+                "seed": 11,
+                "TEST_MODE": 1,
+                "TEST_GOD_MIN_NORM": 9.4,
+                "TEST_GOD_MAX_SE": 0.60,
+                "TEST_GOD_MIN_L2_SEEN": 12,
+                "TEST_GOD_MIN_L2_ACC": 0.80,
+                "TEST_GOD_MIN_OPEN": 16,
+                "TEST_GOD_RUBRIC0": 0.95,
+                "TEST_GOD_RUBRIC1": 0.90,
+                "TEST_OPEN_FULL": 1,
+            },
+        )
+        assert rubric_fail.status_code == 200
+        rubric_payload = rubric_fail.json()
+        assert any(tier != "GOD" for tier in rubric_payload.get("tiers", []))
+        assert any(
+            "open_rubric_low" in (flags or [])
+            for flags in rubric_payload.get("reasons", {}).values()
+        )
+
+        no_force = client.get(
+            "/dev/run",
+            params={
+                "run": "long",
+                "mode": "pass",
+                "seed": 12,
+                "TEST_MODE": 1,
+                "TEST_GOD_MIN_NORM": 0.0,
+                "TEST_GOD_MAX_SE": 1.0,
+                "TEST_GOD_MIN_L2_SEEN": 0,
+                "TEST_GOD_MIN_L2_ACC": 0.0,
+                "TEST_GOD_MIN_OPEN": 16,
+            },
+        )
+        assert no_force.status_code == 200
+        no_force_payload = no_force.json()
+        assert no_force_payload.get("open_used", 0) <= 8
+        assert all(tier != "GOD" for tier in no_force_payload.get("tiers", []))
+        assert any(
+            "open_count_low" in (flags or [])
+            or "open_rubric_low" in (flags or [])
+            for flags in no_force_payload.get("reasons", {}).values()
+        )
+
+        fail = client.get(
+            "/dev/run",
+            params={
+                "run": "long",
+                "mode": "pass",
+                "seed": 13,
+                "TEST_MODE": 1,
+                "TEST_GOD_MIN_NORM": 9.9,
+                "TEST_GOD_MAX_SE": 0.60,
+                "TEST_GOD_MIN_L2_SEEN": 0,
+                "TEST_GOD_MIN_L2_ACC": 0.65,
+                "TEST_GOD_MIN_OPEN": 0,
+                "TEST_OPEN_FULL": 1,
+            },
+        )
+        assert fail.status_code == 200
+        fail_payload = fail.json()
+        assert all(tier != "GOD" for tier in fail_payload.get("tiers", []))
+        fail_reasons = fail_payload.get("reasons", {})
+        assert any("norm_low" in (vals or []) for vals in fail_reasons.values())
+
+        leak_check = client.get("/dev/run", params={"run": "long", "mode": "pass", "seed": 14})
+        assert leak_check.status_code == 200
+        leak_payload = leak_check.json()
+        assert all(tier != "GOD" for tier in leak_payload.get("tiers", []))
+
+        short = client.get("/dev/run", params={"run": "short", "mode": "pass", "seed": 11})
+        assert short.status_code == 200
+        short_payload = short.json()
+        assert short_payload.get("steps") == 40
+        assert short_payload.get("tiers")
+        assert all(tier == "A" for tier in short_payload["tiers"])
+    finally:
+        for key in [
+            "STAGING_PROFILE",
+            "TEST_MODE",
+            "TEST_GOD_MIN_NORM",
+            "TEST_GOD_MAX_SE",
+            "TEST_GOD_MIN_L2_SEEN",
+            "TEST_GOD_MIN_L2_ACC",
+            "TEST_GOD_MIN_OPEN",
+            "TEST_GOD_RUBRIC0",
+            "TEST_GOD_RUBRIC1",
+            "TEST_OPEN_FULL",
+        ]:
+            os.environ.pop(key, None)
+        _reload_app(tmp_path)

--- a/tests/test_api_flows.py
+++ b/tests/test_api_flows.py
@@ -1,0 +1,205 @@
+import importlib
+import os
+import sys
+
+from fastapi.testclient import TestClient
+
+from skill_core.config import GLOBAL_STEP_CAP
+
+_MODULES = [
+    "skill_core.config",
+    "skill_core.plan",
+    "skill_core.engine",
+    "skill_core.policy",
+    "api.storage",
+    "api.app",
+]
+
+
+def _reload_app(tmp_path):
+    os.environ["DATA_DIR"] = str(tmp_path)
+    os.environ.setdefault("DEBUG_SEED", "12345")
+    for name in _MODULES:
+        if name in sys.modules:
+            importlib.reload(sys.modules[name])
+        else:
+            __import__(name)
+    storage = sys.modules["api.storage"]
+    app_module = sys.modules["api.app"]
+    return storage, app_module
+
+
+def _answer_value(item):
+    itype = item.get("type")
+    if itype == "OPEN":
+        return (
+            "Deliver a 3-step plan with 90% accuracy metric, weekly review cadence, validation baseline, "
+            "and a go/no-go decision gate."
+        )
+    if itype == "MCQ":
+        correct = item.get("correct")
+        if isinstance(correct, int):
+            return correct
+        try:
+            return int(correct)
+        except Exception:
+            return 1
+    if itype == "SJT":
+        keys = item.get("keys") or item.get("sjt_keys")
+        if isinstance(keys, dict) and keys:
+            try:
+                return int(max(keys.items(), key=lambda kv: float(kv[1]))[0])
+            except Exception:
+                pass
+        for field in ("best_index", "best", "key_best"):
+            if isinstance(item.get(field), int):
+                return int(item[field])
+        return 1
+    return 3
+
+
+def test_short_end_to_end_ok(tmp_path):
+    _, app_module = _reload_app(tmp_path)
+    client = TestClient(app_module.app)
+
+    start = client.post("/session/start", json={"run": "short", "llm": "none"})
+    assert start.status_code == 200
+    payload = start.json()
+    sid = payload["session_id"]
+
+    steps = 0
+    while True:
+        nxt = client.get(f"/session/{sid}/next")
+        if nxt.status_code == 204:
+            break
+        assert nxt.status_code == 200
+        item = nxt.json().get("item")
+        assert item
+        payload = {"item_id": item["id"], "value": _answer_value(item)}
+        if item.get("type") == "OPEN":
+            payload["rt_ms"] = 2500
+        else:
+            payload["rt_ms"] = 2000
+        ans = client.post(f"/session/{sid}/answer", json=payload)
+        assert ans.status_code == 200
+        steps += 1
+        if ans.json().get("done"):
+            break
+        assert steps <= GLOBAL_STEP_CAP
+
+    finish = client.post("/session/finish", json={"session_id": sid})
+    assert finish.status_code == 200
+    report = finish.json()
+    tiers = [str(d.get("tier", "")) for d in report.get("domain_scores", [])]
+    assert tiers, "Expected domain tiers in report"
+    assert all(tier in {"F", "D", "C", "B", "A"} for tier in tiers)
+
+    summary = report.get("summary") or {}
+    assert summary.get("steps_used") == steps
+    cap_str = summary.get("cap", "")
+    assert cap_str.startswith(f"{steps}/")
+    assert summary.get("sr_used", 0) >= 0
+    assert summary.get("open_used", 0) == 0
+def test_long_finish_requires_done(tmp_path):
+    _, app_module = _reload_app(tmp_path)
+    client = TestClient(app_module.app)
+
+    start = client.post("/session/start", json={"run": "long", "llm": "none"})
+    assert start.status_code == 200
+    sid = start.json()["session_id"]
+
+    nxt = client.get(f"/session/{sid}/next")
+    assert nxt.status_code == 200
+    item = nxt.json().get("item")
+    assert item
+    payload = {"item_id": item["id"], "value": _answer_value(item), "rt_ms": 2000}
+    ans = client.post(f"/session/{sid}/answer", json=payload)
+    assert ans.status_code == 200
+
+    attempt = client.post("/session/finish", json={"session_id": sid})
+    assert attempt.status_code == 409
+    assert attempt.json()["status"] == "continue"
+
+    steps = 1
+    while True:
+        nxt = client.get(f"/session/{sid}/next")
+        if nxt.status_code == 204:
+            break
+        assert nxt.status_code == 200
+        item = nxt.json().get("item")
+        assert item
+        payload = {"item_id": item["id"], "value": _answer_value(item)}
+        if item.get("type") == "OPEN":
+            payload["rt_ms"] = 2500
+        else:
+            payload["rt_ms"] = 2000
+        ans = client.post(f"/session/{sid}/answer", json=payload)
+        assert ans.status_code == 200
+        steps += 1
+        if ans.json().get("done"):
+            break
+        assert steps <= GLOBAL_STEP_CAP
+
+    finish = client.post("/session/finish", json={"session_id": sid})
+    assert finish.status_code == 200
+    report = finish.json()
+    summary = report.get("summary") or {}
+    assert summary.get("steps_used") == steps
+    cap_str = summary.get("cap", "")
+    assert cap_str, "cap summary should be present"
+    used_str, _, limit_str = cap_str.partition("/")
+    used_val = int(used_str)
+    limit_val = int(limit_str)
+    assert used_val == summary.get("steps_used")
+    assert limit_val == GLOBAL_STEP_CAP
+    assert summary.get("sr_used") == 16
+    assert summary.get("open_used") >= 8
+    assert used_val <= GLOBAL_STEP_CAP
+
+
+def test_dev_run_modes(tmp_path):
+    os.environ["STAGING_PROFILE"] = "1"
+    try:
+        _, app_module = _reload_app(tmp_path)
+        client = TestClient(app_module.app)
+
+        short_resp = client.get("/dev/run", params={"run": "short", "mode": "pass", "seed": 11})
+        assert short_resp.status_code == 200
+        short_payload = short_resp.json()
+        assert short_payload["steps"] == 40
+        assert len(short_payload["tiers"]) == 8
+        assert all(tier in {"F", "D", "C", "B", "A"} for tier in short_payload["tiers"])
+
+        long_pass = client.get("/dev/run", params={"run": "long", "mode": "pass", "seed": 11})
+        assert long_pass.status_code == 200
+        long_payload = long_pass.json()
+        assert str(long_payload.get("cap", "")).endswith("/160")
+        assert long_payload.get("sr_used") == 16
+        assert int(long_payload.get("open_used", 0)) >= 8
+
+        long_fail = client.get("/dev/run", params={"run": "long", "mode": "fail", "seed": 11})
+        assert long_fail.status_code == 200
+        fail_payload = long_fail.json()
+        assert int(fail_payload.get("open_used", 0)) <= 8
+    finally:
+        os.environ.pop("STAGING_PROFILE", None)
+        _reload_app(tmp_path)
+
+
+def test_dev_run_force_open(tmp_path):
+    os.environ["STAGING_PROFILE"] = "1"
+    os.environ["TEST_MODE"] = "1"
+    os.environ["TEST_OPEN_FULL"] = "1"
+    try:
+        _, app_module = _reload_app(tmp_path)
+        client = TestClient(app_module.app)
+
+        forced = client.get("/dev/run", params={"run": "long", "mode": "pass", "seed": 11})
+        assert forced.status_code == 200
+        payload = forced.json()
+        assert payload.get("sr_used") == 16
+        assert payload.get("open_used") == 16
+    finally:
+        for key in ("STAGING_PROFILE", "TEST_MODE", "TEST_OPEN_FULL"):
+            os.environ.pop(key, None)
+        _reload_app(tmp_path)

--- a/tests/test_audit_export.py
+++ b/tests/test_audit_export.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+
+from fastapi.testclient import TestClient
+
+from tests.conftest import build_synthetic_bank
+
+
+_DEF_MODULES = [
+    "skill_core.config",
+    "api.storage",
+    "api.app",
+]
+
+
+def _reload_app(tmp_path) -> tuple[object, object]:
+    os.environ["DATA_DIR"] = str(tmp_path)
+    for name in _DEF_MODULES:
+        if name in sys.modules:
+            importlib.reload(sys.modules[name])
+        else:
+            __import__(name)
+    storage = sys.modules["api.storage"]
+    app_module = sys.modules["api.app"]
+    return storage, app_module
+
+
+def test_audit_exports_available(tmp_path, monkeypatch):
+    _storage, app_module = _reload_app(tmp_path / "enabled")
+    import skill_core.question_bank as qb
+
+    monkeypatch.setattr(qb, "load_bank", lambda: build_synthetic_bank())
+
+    client = TestClient(app_module.app)
+
+    start = client.post("/session/start", json={"run": "long", "llm": "none"})
+    assert start.status_code == 200
+    sid = start.json()["session_id"]
+
+    first = client.get("/api/test/next", params={"session_id": sid})
+    assert first.status_code == 200
+    item = first.json()["item"]
+    assert item
+
+    answer_payload = {
+        "session_id": sid,
+        "item_id": item["id"],
+        "answer": 0 if item["type"] in {"MCQ", "SJT"} else "4",
+        "started_at": 0.0,
+        "submitted_at": 1.0,
+    }
+    resp_answer = client.post("/api/test/answer", json=answer_payload)
+    assert resp_answer.status_code == 200
+
+    finish = client.post("/api/test/finish", json={"session_id": sid})
+    assert finish.status_code == 200
+    report = finish.json()
+    report_id = report.get("reportId") or report.get("id")
+    assert report_id
+
+    json_resp = client.get(f"/results/{report_id}/audit.json")
+    assert json_resp.status_code == 200
+    body = json_resp.json()
+    events = body.get("events") or []
+    assert events, "expected at least one audit event"
+    first_event = events[0]
+    required = {
+        "t",
+        "domain",
+        "item_id",
+        "type",
+        "b",
+        "level_before",
+        "level_after",
+        "correct_or_r",
+        "theta_before",
+        "theta_after",
+        "se_after",
+        "latency_ms",
+    }
+    assert required.issubset(first_event.keys())
+
+    csv_resp = client.get(f"/results/{report_id}/audit.csv")
+    assert csv_resp.status_code == 200
+    csv_lines = [line for line in csv_resp.text.strip().splitlines() if line]
+    assert len(csv_lines) == len(events) + 1
+    header = csv_lines[0].split(",")
+    assert header[0] == "t"
+    assert header[-1] == "latency_ms"
+
+
+def test_audit_exports_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("AUDIT_EXPORT_ENABLED", "0")
+    storage, app_module = _reload_app(tmp_path / "disabled")
+
+    payload = {
+        "run_type": "long",
+        "audit_events": [
+            {
+                "t": "2024-01-01T00:00:00+00:00",
+                "domain": "Analytical",
+                "item_id": "x1",
+                "type": "MCQ",
+                "b": 0,
+                "level_before": 0,
+                "level_after": 0,
+                "correct_or_r": 1.0,
+                "theta_before": 0.0,
+                "theta_after": 0.1,
+                "se_after": 0.9,
+                "latency_ms": 1200,
+            }
+        ],
+        "meta": {},
+        "summary": {},
+    }
+    report_id = "audit-disabled"
+    path = storage.REPORTS_DIR / f"{report_id}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    client = TestClient(app_module.app)
+
+    json_resp = client.get(f"/results/{report_id}/audit.json")
+    csv_resp = client.get(f"/results/{report_id}/audit.csv")
+    assert json_resp.status_code == 404
+    assert csv_resp.status_code == 404

--- a/tests/test_bank_audit.py
+++ b/tests/test_bank_audit.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import skill_core.audit_bank as audit_bank
+from skill_core import config
+from skill_core.types import Item
+from tests.conftest import build_synthetic_bank
+from tools import fix_variant_groups
+
+
+def test_audit_flags_sparse_buckets(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "BANK_MIN_PER_BUCKET_OBJ", 2, raising=False)
+    monkeypatch.setattr(config, "BANK_MIN_PER_BUCKET_OPEN", 2, raising=False)
+
+    bank = build_synthetic_bank(domains=["Analytical"], mcq_per_level=1, include_sr=False)
+
+    summary = audit_bank.audit_items(bank)
+    assert summary["warnings"], "expected sparse coverage warnings"
+    joined = "\n".join(summary["warnings"])
+    assert "Analytical MCQ level -2" in joined
+    assert "Analytical OPEN level -1" in joined
+
+    outfile = tmp_path / "bank_audit.json"
+    text = audit_bank.write_summary(summary, path=outfile)
+    assert outfile.read_text(encoding="utf-8").strip() == text
+
+
+def test_audit_flags_missing_variant_group(monkeypatch):
+    monkeypatch.setattr(config, "BANK_MIN_PER_BUCKET_OBJ", 0, raising=False)
+    monkeypatch.setattr(config, "BANK_MIN_PER_BUCKET_OPEN", 0, raising=False)
+    monkeypatch.setattr(config, "BANK_EXPECT_VARIANT_GROUP", True, raising=False)
+
+    item = Item(id="a1", domain="Analytical", type="MCQ", text="t", difficulty=0)
+    summary = audit_bank.audit_items([item])
+
+    assert summary["coverage"]["Analytical"]["missing_variant_group"] == 1
+    assert any("missing variant_group" in w for w in summary["warnings"])
+
+
+def test_main_returns_warning_exit(monkeypatch, capsys):
+    monkeypatch.setattr(config, "BANK_MIN_PER_BUCKET_OBJ", 2, raising=False)
+    monkeypatch.setattr(config, "BANK_MIN_PER_BUCKET_OPEN", 2, raising=False)
+
+    bank = build_synthetic_bank(domains=["Analytical"], mcq_per_level=1, include_sr=False)
+    monkeypatch.setattr(audit_bank, "load_bank", lambda: bank)
+
+    exit_code = audit_bank.main([])
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "Analytical" in captured.out
+    assert Path("/tmp/bank_audit.json").exists()
+
+
+def test_main_allow_warn_flag(monkeypatch, capsys):
+    monkeypatch.setattr(config, "BANK_MIN_PER_BUCKET_OBJ", 2, raising=False)
+    monkeypatch.setattr(config, "BANK_MIN_PER_BUCKET_OPEN", 2, raising=False)
+
+    bank = build_synthetic_bank(domains=["Analytical"], mcq_per_level=1, include_sr=False)
+    monkeypatch.setattr(audit_bank, "load_bank", lambda: bank)
+
+    exit_code = audit_bank.main(["--allow-warn"])
+    out = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "AUDIT:" in out
+    assert "allow_warn=True" in out
+
+
+def test_audit_override_thresholds_reduce_warnings(monkeypatch):
+    monkeypatch.setattr(config, "BANK_MIN_PER_BUCKET_OBJ", 20, raising=False)
+    monkeypatch.setattr(config, "BANK_MIN_PER_BUCKET_OPEN", 10, raising=False)
+
+    bank = build_synthetic_bank(domains=["Analytical"], mcq_per_level=12, include_sr=False)
+
+    baseline = audit_bank.audit_items(bank)
+    relaxed = audit_bank.audit_items(bank, min_obj=10, min_open=5)
+
+    assert len(relaxed["warnings"]) < len(baseline["warnings"])
+
+
+def test_fix_variant_groups_script(tmp_path):
+    bank_path = tmp_path / "bank.json"
+    payload = [
+        {
+            "id": "item1",
+            "domain": "Analytical",
+            "type": "MCQ",
+            "text": "Q1",
+            "difficulty": 0,
+        },
+        {
+            "id": "item2",
+            "domain": "Analytical",
+            "type": "OPEN",
+            "text": "Describe",
+            "difficulty": 1,
+            "variant_group": "preset",
+        },
+    ]
+    bank_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    # Dry run does not create file
+    exit_code = fix_variant_groups.main(["--pattern", str(bank_path)])
+    assert exit_code == 0
+    patched_path = Path(f"{bank_path}.patched{bank_path.suffix}")
+    assert not patched_path.exists()
+
+    exit_code = fix_variant_groups.main(["--pattern", str(bank_path), "--apply"])
+    assert exit_code == 0
+    assert patched_path.exists()
+
+    patched = json.loads(patched_path.read_text(encoding="utf-8"))
+    assert patched[0]["variant_group"].startswith("Analytical:MCQ:0:")
+    assert patched[1]["variant_group"] == "preset"

--- a/tests/test_caps_minima.py
+++ b/tests/test_caps_minima.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+
+from skill_core import engine as eng
+from skill_core.config import CAP_LONG, OBJ_MIN_LONG
+from skill_core.policy import DomainHistory, PolicyState, QuestionPolicy
+from skill_core.question_bank import DOMAINS
+from skill_core.report_html import export_report_html
+
+from tests.conftest import build_synthetic_bank
+
+
+def test_objective_minima_are_fulfilled_before_sr_or_open():
+    bank = build_synthetic_bank()
+    policy = QuestionPolicy(bank, "long")
+    hist = {domain: DomainHistory() for domain in DOMAINS}
+    state = PolicyState(
+        run_type="long",
+        theta={domain: 0.0 for domain in DOMAINS},
+        se={domain: 1.0 for domain in DOMAINS},
+        asked=set(),
+        seen_variant_groups=set(),
+        step=0,
+        hist=hist,
+        info_history=[],
+    )
+
+    for _ in range(OBJ_MIN_LONG * len(DOMAINS)):
+        item = policy.next_item(state)
+        assert item is not None
+        assert item.type in {"MCQ", "SJT"}
+        state.step += 1
+        state.asked.add(item.id)
+        vg = getattr(item, "variant_group", None)
+        if vg:
+            state.seen_variant_groups.add(vg)
+        domain_hist = state.hist[item.domain]
+        domain_hist.obj_count += 1
+        domain_hist.asked_ids.append(item.id)
+        state.last_domain_id = item.domain
+
+    assert all(hist[d].obj_count >= OBJ_MIN_LONG for d in DOMAINS)
+
+
+def test_finalize_marks_incomplete_when_cap_hits_before_minima(tmp_path, monkeypatch):
+    bank = build_synthetic_bank()
+    monkeypatch.setattr(eng, "load_bank", lambda: list(bank))
+
+    session = eng.AdaptiveSession("long")
+    for domain in DOMAINS:
+        session.state.domains[domain].obj_count = OBJ_MIN_LONG - 1
+    session._step = CAP_LONG
+
+    result = session.finalize()
+    meta = getattr(result, "meta", {})
+    assert meta.get("incomplete") is True
+    assert meta.get("incomplete_reason") == "CAP_BEFORE_MINIMA"
+    shortfalls = meta.get("shortfalls")
+    assert shortfalls and all(val == 1 for val in shortfalls.values())
+
+    payload = {
+        "run_type": result.run_type,
+        "summary": result.summary,
+        "meta": meta,
+        "domain_scores": [json.loads(json.dumps(ds.__dict__)) for ds in result.domain_scores],
+    }
+
+    out_path = tmp_path / "report.html"
+    export_report_html(payload, str(out_path))
+    html = out_path.read_text(encoding="utf-8")
+
+    assert "Run hit step cap before completing minimum objectives" in html
+    for domain in DOMAINS:
+        assert f"{domain}: needs 1 more objective item" in html
+

--- a/tests/test_demote_guard.py
+++ b/tests/test_demote_guard.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from skill_core.engine import DomainState, _apply_objective_step
+
+
+def test_first_miss_does_not_demote_and_subsequent_misses_do():
+    state = DomainState(level=0)
+
+    for difficulty, correct in [
+        (0, True),
+        (0, True),
+        (0, False),
+    ]:
+        _apply_objective_step(state, difficulty, correct, "short")
+
+    assert state.level == 1, "Initial streak should promote to level +1"
+
+    _apply_objective_step(state, 1, False, "short")
+    assert state.level == 1, "First item at a new level cannot demote"
+
+    before_drop = state.level
+    _apply_objective_step(state, 1, False, "short")
+    metrics = _apply_objective_step(state, 1, False, "short")
+    assert state.level == 0, "Two misses in the last three should demote by one level"
+    assert metrics["level_before"] == before_drop and metrics["level_after"] == before_drop - 1
+

--- a/tests/test_ladder_long.py
+++ b/tests/test_ladder_long.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from skill_core.config import OBJ_MAX_LONG
+from skill_core.engine import DomainState, _apply_objective_step
+
+
+def test_long_run_reaches_top_level_with_three_of_four_rule():
+    state = DomainState(level=-1)
+    sequence = [
+        (-1, True),
+        (-1, True),
+        (-1, True),
+        (-1, False),
+        (0, True),
+        (0, True),
+        (0, True),
+        (0, False),
+        (1, True),
+        (1, True),
+        (1, True),
+        (1, False),
+        (2, True),
+        (2, True),
+        (2, True),
+        (2, True),
+    ]
+
+    for idx, (difficulty, correct) in enumerate(sequence, start=1):
+        metrics = _apply_objective_step(state, difficulty, correct, "long")
+        if idx < 4:
+            assert metrics["level_after"] == -1, "Long run should require 3/4 window before promoting"
+        if idx == 4:
+            assert metrics["level_before"] == -1 and metrics["level_after"] == 0
+
+    assert state.level == 2, "Long ladder should climb to +2"
+    assert state.b_stable == 2, "Sustained success at the top should mark level +2 as stable"
+    assert state.obj_count <= OBJ_MAX_LONG, "Objective count must respect long-run cap"
+

--- a/tests/test_ladder_short.py
+++ b/tests/test_ladder_short.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from skill_core.engine import DomainState, _apply_objective_step
+
+
+def test_short_run_stays_within_band_and_promotes_to_plus_one():
+    state = DomainState(level=-1)
+    sequence = [
+        (-1, True),
+        (-1, True),
+        (-1, False),  # two of three correct -> promote to 0
+        (0, True),
+        (0, True),
+        (0, False),   # promotion to +1 after three items at level 0
+        (1, True),
+        (1, False),
+        (1, True),
+    ]
+
+    seen_levels = []
+    for idx, (difficulty, correct) in enumerate(sequence, start=1):
+        metrics = _apply_objective_step(state, difficulty, correct, "short")
+        seen_levels.append(metrics["level_after"])
+        assert -1 <= metrics["level_after"] <= 1, "Short ladder must remain within -1..+1 band"
+        if idx == 3:
+            assert metrics["level_before"] == -1 and metrics["level_after"] == 0
+        if idx == 6:
+            assert metrics["level_before"] == 0 and metrics["level_after"] == 1
+
+    assert state.level == 1, "Short ladder should peak at +1 under new policy"
+    assert state.b_stable <= 1, "Stable level cannot exceed band"
+    assert any(level == 1 for level in seen_levels), "Progression should capture promotion to +1"
+

--- a/tests/test_open_residual.py
+++ b/tests/test_open_residual.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from skill_core.config import OPEN_INFO_CAP_RATIO
+from skill_core.engine import DomainState, _apply_open_step
+
+
+def _prep(theta: float, obj_info: float) -> DomainState:
+    state = DomainState()
+    state.theta = theta
+    state.obj_info_total = obj_info
+    state.info_total = obj_info + 1.0
+    return state
+
+
+def test_open_residual_updates_and_caps():
+    positive = _prep(0.8, 10.0)
+    metrics_high = _apply_open_step(
+        positive,
+        difficulty=1,
+        score=0.70,
+        word_count=180,
+        latency_ms=2500,
+        rubric_conf=0.8,
+    )
+
+    assert metrics_high["dtheta"] > 0.0, "Residual above expectation should raise theta"
+
+    smaller = _prep(0.8, 10.0)
+    metrics_low = _apply_open_step(
+        smaller,
+        difficulty=-1,
+        score=0.70,
+        word_count=180,
+        latency_ms=2500,
+        rubric_conf=0.8,
+    )
+
+    assert metrics_low["dtheta"] < metrics_high["dtheta"]
+    cap = OPEN_INFO_CAP_RATIO * smaller.obj_info_total
+    assert smaller.open_info_total <= cap + 1e-9
+
+    ignored = _prep(0.8, 10.0)
+    before_theta = ignored.theta
+    metrics_ignored = _apply_open_step(
+        ignored,
+        difficulty=1,
+        score=0.9,
+        word_count=50,
+        latency_ms=200,
+        rubric_conf=0.9,
+    )
+    assert metrics_ignored.get("ignored") == "latency"
+    assert abs(ignored.theta - before_theta) < 1e-9
+

--- a/tests/test_plan_endpoint.py
+++ b/tests/test_plan_endpoint.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+
+from fastapi.testclient import TestClient
+
+from skill_core.config import PLAN_BULLETS_MAX, PLAN_BULLETS_MIN, PLAN_FOCUS_MAX
+
+_MODULES = [
+    "skill_core.config",
+    "skill_core.plan",
+    "api.storage",
+    "api.app",
+]
+
+
+def _reload_app(tmp_path) -> tuple[object, object]:
+    os.environ["DATA_DIR"] = str(tmp_path)
+    for name in _MODULES:
+        if name in sys.modules:
+            importlib.reload(sys.modules[name])
+        else:
+            __import__(name)
+    storage = sys.modules["api.storage"]
+    app_module = sys.modules["api.app"]
+    return storage, app_module
+
+
+def _write_report(storage, report_id: str, payload: dict) -> None:
+    path = storage.REPORTS_DIR / f"{report_id}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_plan_endpoint_idempotent_enabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("PLAN_ENABLED", "1")
+    storage, app_module = _reload_app(tmp_path)
+    client = TestClient(app_module.app)
+
+    long_payload = {
+        "run_type": "long",
+        "summary": {"total_items": 120},
+        "meta": {"run": "long", "total_items": 120},
+        "domain_scores": [
+            {
+                "domain": "Analytical",
+                "tier": "D",
+                "theta": -0.2,
+                "se": 0.35,
+                "b_stable": 0,
+                "items_by_level": {0: 8},
+                "accuracy_by_level": {0: 0.5},
+            },
+            {
+                "domain": "Mathematical",
+                "tier": "C",
+                "theta": 0.1,
+                "se": 0.28,
+                "b_stable": 1,
+                "items_by_level": {1: 10},
+                "accuracy_by_level": {1: 0.6},
+            },
+            {
+                "domain": "Verbal",
+                "tier": "B",
+                "theta": 0.4,
+                "se": 0.22,
+                "b_stable": 1,
+                "items_by_level": {1: 9},
+                "accuracy_by_level": {1: 0.7},
+            },
+        ],
+    }
+
+    _write_report(storage, "report-long", long_payload)
+
+    resp1 = client.post("/results/report-long/plan")
+    assert resp1.status_code == 200
+    body1 = resp1.json()
+    plan = body1.get("plan")
+    assert plan and 2 <= len(plan) <= PLAN_FOCUS_MAX
+    for entry in plan:
+        goals = entry.get("goals", [])
+        assert PLAN_BULLETS_MIN <= len(goals) <= PLAN_BULLETS_MAX
+
+    resp2 = client.post("/results/report-long/plan")
+    assert resp2.status_code == 200
+    assert resp2.json()["plan"] == plan, "Subsequent calls should return cached plan"
+
+    short_payload = {
+        "run_type": "short",
+        "summary": {"total_items": 40},
+        "meta": {"run": "short", "total_items": 40},
+        "domain_scores": long_payload["domain_scores"],
+    }
+    _write_report(storage, "report-short", short_payload)
+
+    resp_short = client.post("/results/report-short/plan")
+    assert resp_short.status_code == 200
+    assert resp_short.json().get("plan") == []
+
+
+def test_plan_endpoint_disabled_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("PLAN_ENABLED", "0")
+    storage, app_module = _reload_app(tmp_path)
+    client = TestClient(app_module.app)
+
+    long_payload = {
+        "run_type": "long",
+        "summary": {"total_items": 120},
+        "meta": {"run": "long", "total_items": 120},
+        "domain_scores": [
+            {
+                "domain": "Analytical",
+                "tier": "D",
+                "theta": -0.2,
+                "se": 0.35,
+                "b_stable": 0,
+            }
+        ],
+    }
+
+    _write_report(storage, "report-disabled", long_payload)
+
+    resp = client.post("/results/report-disabled/plan")
+    assert resp.status_code == 200
+    assert resp.json().get("plan") == []
+

--- a/tests/test_rasch.py
+++ b/tests/test_rasch.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from skill_core.engine import DomainState, _apply_objective_step
+
+
+def _monotonic(values: list[float]) -> bool:
+    return all(b <= a + 1e-6 for a, b in zip(values, values[1:]))
+
+
+def test_rasch_updates_reduce_se_and_raise_theta():
+    state = DomainState(level=0)
+    se_values: list[float] = []
+    theta_values: list[float] = []
+
+    for _ in range(10):
+        _apply_objective_step(state, 0, True, "long")
+        se_values.append(state.se)
+        theta_values.append(state.theta)
+
+    assert _monotonic(se_values), "SE should decrease for repeated correct answers"
+    assert all(
+        b >= a - 1e-6 for a, b in zip(theta_values, theta_values[1:])
+    ), "Theta should increase with consistent success"
+
+
+def test_rasch_balanced_answers_keep_theta_near_zero():
+    state = DomainState(level=0)
+    se_values: list[float] = []
+
+    for idx in range(12):
+        correct = (idx % 2) == 0
+        _apply_objective_step(state, 0, correct, "long")
+        se_values.append(state.se)
+
+    assert _monotonic(se_values), "SE should still shrink with mixed performance"
+    assert abs(state.theta) < 0.3, "Alternating answers should stabilise theta around zero"
+

--- a/tests/test_short_policy.py
+++ b/tests/test_short_policy.py
@@ -1,0 +1,197 @@
+import pytest
+
+from skill_core import engine as eng
+from skill_core.policy import DomainHistory, PolicyState, QuestionPolicy
+from skill_core.config import (
+    CAP_SHORT,
+    SHORT_OBJ_MIN,
+    SHORT_OBJ_MAX,
+    SHORT_EXTRA_TOTAL,
+    SHORT_SR_PER_DOMAIN,
+    SHORT_LEVELS,
+    SHORT_START_LEVEL,
+    TIER_NAMES,
+)
+from skill_core.question_bank import DOMAINS
+from skill_core.types import Answer
+
+from tests.conftest import build_synthetic_bank
+
+
+def _run_short_session(monkeypatch):
+    bank = build_synthetic_bank(include_open=False)
+    monkeypatch.setattr(eng, "load_bank", lambda: list(bank))
+    monkeypatch.setattr(eng.random, "shuffle", lambda seq: None)
+
+    import skill_core.policy as policy_mod
+
+    monkeypatch.setattr(policy_mod, "DEBUG_SEED", 12345)
+
+    session = eng.AdaptiveSession("short")
+    initial_levels = {dom: session.state.domains[dom].level for dom in DOMAINS}
+    served = []
+
+    while True:
+        item = session.next_item()
+        if item is None:
+            break
+        served.append(item)
+        if item.type in {"MCQ", "SJT"}:
+            value = int(getattr(item, "correct", 0) or 0)
+            answer = Answer(item_id=item.id, value=value, rt_sec=30.0)
+        elif item.type == "SR":
+            answer = Answer(item_id=item.id, value=4, rt_sec=5.0)
+        else:
+            answer = Answer(item_id=item.id, value="", rt_sec=45.0)
+        session.answer_current(answer)
+
+    result = session.finalize()
+    return session, served, result, initial_levels
+
+
+@pytest.fixture
+def short_session(monkeypatch):
+    return _run_short_session(monkeypatch)
+
+
+def test_minima_counts(short_session):
+    session, served, _, _ = short_session
+    for domain in DOMAINS:
+        st = session.state.domains[domain]
+        assert st.obj_count >= SHORT_OBJ_MIN
+        assert st.obj_count <= SHORT_OBJ_MAX
+    obj_total = sum(session.state.domains[d].obj_count for d in DOMAINS)
+    assert obj_total >= SHORT_OBJ_MIN * len(DOMAINS)
+
+
+def test_sr_counts(short_session):
+    session, served, _, _ = short_session
+    obj_progress = {dom: 0 for dom in DOMAINS}
+    for item in served:
+        if item.type in {"MCQ", "SJT"}:
+            obj_progress[item.domain] += 1
+        elif item.type == "SR":
+            assert (
+                obj_progress[item.domain] >= SHORT_OBJ_MIN
+            ), "SR must follow objective minima"
+    for domain in DOMAINS:
+        assert session.state.domains[domain].sr_count == SHORT_SR_PER_DOMAIN
+
+
+def test_level_banding(short_session):
+    session, served, _, initial_levels = short_session
+    for domain, level in initial_levels.items():
+        assert level == SHORT_START_LEVEL, "Short runs should start at configured level"
+    allowed = set(SHORT_LEVELS)
+    for item in served:
+        if item.type in {"MCQ", "SJT"}:
+            assert int(getattr(item, "difficulty", 0)) in allowed
+
+
+def test_extra_allocation(monkeypatch):
+    bank = build_synthetic_bank(include_open=False)
+    policy = QuestionPolicy(bank, "short")
+    hist = {dom: DomainHistory() for dom in DOMAINS}
+    se_values = {
+        dom: 1.0 - idx * 0.05 for idx, dom in enumerate(DOMAINS)
+    }
+    step_base = (SHORT_OBJ_MIN + SHORT_SR_PER_DOMAIN) * len(DOMAINS)
+    for dom in DOMAINS:
+        hist[dom].obj_count = SHORT_OBJ_MIN
+        hist[dom].sr_count = SHORT_SR_PER_DOMAIN
+        hist[dom].level = 0
+    state = PolicyState(
+        run_type="short",
+        theta={dom: 0.0 for dom in DOMAINS},
+        se=se_values,
+        asked=set(),
+        seen_variant_groups=set(),
+        step=step_base,
+        hist=hist,
+        info_history=[],
+        mirrored_domains_planned=set(),
+        last_domain_id=None,
+        last_item_type="MCQ",
+    )
+
+    extras_taken = {dom: 0 for dom in DOMAINS}
+    expected_total = min(
+        SHORT_EXTRA_TOTAL,
+        max(0, CAP_SHORT - step_base),
+    )
+
+    while sum(extras_taken.values()) < expected_total:
+        item = policy.next_item(state)
+        assert item is not None, "Policy should allocate expected extras"
+        assert item.type in {"MCQ", "SJT"}
+        dom_hist = state.hist[item.domain]
+        dom_hist.obj_count += 1
+        extras_taken[item.domain] = max(0, dom_hist.obj_count - SHORT_OBJ_MIN)
+        dom_hist.asked_ids.append(item.id)
+        state.asked.add(item.id)
+        vg = getattr(item, "variant_group", None)
+        if vg:
+            state.seen_variant_groups.add(vg)
+        state.step += 1
+        state.last_domain_id = item.domain
+        state.last_item_type = item.type
+
+    ordered = sorted(DOMAINS, key=lambda d: se_values[d], reverse=True)
+    top_four = ordered[:4]
+    for dom in top_four:
+        assert extras_taken[dom] <= min(2, SHORT_OBJ_MAX - SHORT_OBJ_MIN)
+    others = [dom for dom in DOMAINS if dom not in top_four]
+    for dom in others:
+        assert extras_taken[dom] == 0
+    assert sum(extras_taken.values()) == expected_total
+    for dom in DOMAINS:
+        assert state.hist[dom].obj_count <= SHORT_OBJ_MAX
+
+
+def test_short_extras_top4_only(short_session):
+    session, _, result, _ = short_session
+    extras = []
+    for domain in DOMAINS:
+        st = session.state.domains[domain]
+        assert SHORT_OBJ_MIN <= st.obj_count <= SHORT_OBJ_MAX
+        extras.append(max(0, st.obj_count - SHORT_OBJ_MIN))
+
+    extras_total = sum(extras)
+    expected_total = min(
+        SHORT_EXTRA_TOTAL,
+        max(0, CAP_SHORT - (SHORT_OBJ_MIN + SHORT_SR_PER_DOMAIN) * len(DOMAINS)),
+    )
+    assert extras_total == expected_total
+
+    domains_with_extras = sum(1 for val in extras if val > 0)
+    assert domains_with_extras <= 4
+    assert all(val <= (SHORT_OBJ_MAX - SHORT_OBJ_MIN) for val in extras)
+
+
+def test_short_total_steps_approx40(short_session):
+    session, _, result, _ = short_session
+    expected_extras = min(
+        SHORT_EXTRA_TOTAL,
+        max(0, CAP_SHORT - (SHORT_OBJ_MIN + SHORT_SR_PER_DOMAIN) * len(DOMAINS)),
+    )
+    expected_steps = (
+        SHORT_OBJ_MIN * len(DOMAINS)
+        + SHORT_SR_PER_DOMAIN * len(DOMAINS)
+        + expected_extras
+    )
+    assert session._step == expected_steps
+    assert result.summary.get("steps_total", 0) == expected_steps
+
+
+def test_cap(short_session):
+    session, _, result, _ = short_session
+    assert session._step <= CAP_SHORT
+    assert result.summary.get("steps_total", 0) <= CAP_SHORT
+
+
+def test_tier_cap(short_session):
+    _, _, result, _ = short_session
+    cap_index = TIER_NAMES.index("A")
+    for score in result.domain_scores:
+        tier_index = TIER_NAMES.index(score.tier)
+        assert tier_index <= cap_index

--- a/tests/test_sr_prior_only.py
+++ b/tests/test_sr_prior_only.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from skill_core.config import SR_START_SHIFT
+import skill_core.engine as eng
+from skill_core.engine import DomainState, _composite, _sr_shift_from_mean
+from skill_core.question_bank import DOMAINS
+
+from tests.conftest import build_synthetic_bank
+
+
+def test_sr_weight_zero_in_composite():
+    domain = DOMAINS[0]
+    low_obj = DomainState(theta=-0.5, mcq_total=4, mcq_correct=1)
+    sr_heavy = DomainState(theta=-0.5, mcq_total=4, mcq_correct=1, sr_sum=40.0, sr_total=40)
+
+    score_low, _, parts_low = _composite(domain, low_obj)
+    score_sr, _, parts_sr = _composite(domain, sr_heavy)
+
+    assert abs(score_low - score_sr) < 1e-9, "SR responses must not change the composite score"
+    assert parts_sr["sr"] == 100.0 and parts_low["sr"] == 0.0
+
+
+def test_sr_shift_mapping_boundaries():
+    assert _sr_shift_from_mean(2.0) == SR_START_SHIFT.get("low", -1)
+    assert _sr_shift_from_mean(3.5) == SR_START_SHIFT.get("mid", 0)
+    assert _sr_shift_from_mean(4.8) == SR_START_SHIFT.get("high", 1)
+
+
+def test_start_level_defaults_and_prior_override(monkeypatch):
+    bank = build_synthetic_bank(include_open=False)
+    monkeypatch.setattr(eng, "load_bank", lambda: list(bank))
+
+    monkeypatch.setattr(eng, "load_config", lambda: {})
+    session_default = eng.AdaptiveSession("short")
+    assert all(
+        session_default.state.domains[d].level == 0 for d in DOMAINS
+    ), "Default start level should be 0 when no priors"
+
+    sr_cfg = {d: 4.8 for d in DOMAINS}
+    monkeypatch.setattr(eng, "load_config", lambda: {"sr_means": sr_cfg})
+    session_sr = eng.AdaptiveSession("long")
+    assert all(
+        session_sr.state.domains[d].level in {0, 1}
+        for d in DOMAINS
+    ), "SR shift must remain within ±1"
+
+    prior_cfg = {d: 1.6 for d in DOMAINS}
+    monkeypatch.setattr(
+        eng,
+        "load_config",
+        lambda: {"sr_means": sr_cfg, "theta_priors": prior_cfg},
+    )
+    session_prior = eng.AdaptiveSession("long")
+    assert all(
+        session_prior.state.domains[d].level == 2 for d in DOMAINS
+    ), "Rounded prior theta should override SR shift within level bounds"
+

--- a/tests/test_tier_god.py
+++ b/tests/test_tier_god.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+
+import skill_core.config as cfg
+import skill_core.engine as engine
+
+
+def _state(**overrides):
+    base = {
+        "b_stable": 2,
+        "se": 0.18,
+        "items_by_level": {2: 5},
+        "accuracy_by_level": {2: 0.85},
+        "open_count": 2,
+        "open_ratings": [0.86, 0.80],
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_god_gate_passes_with_all_requirements():
+    state = _state()
+    tier = engine.map_tier(9.9, "long", state)
+    assert tier == "GOD"
+    gate = getattr(state, "_tier_meta", {}).get("god_gate", {})
+    assert gate.get("status") == "pass"
+
+
+def test_god_gate_requires_low_se():
+    state = _state(se=0.26)
+    tier = engine.map_tier(9.9, "long", state)
+    assert tier == "SS"
+    gate = getattr(state, "_tier_meta", {}).get("god_gate", {})
+    assert gate.get("status") == "near"
+    assert gate.get("se_ok") is False
+    assert "se_high" in gate.get("reasons", [])
+
+
+def test_god_gate_requires_two_open():
+    state = _state(open_count=1, open_ratings=[0.86])
+    tier = engine.map_tier(9.9, "long", state)
+    assert tier == "SS"
+    gate = getattr(state, "_tier_meta", {}).get("god_gate", {})
+    assert gate.get("open_count_ok") is False
+    assert "open_count_low" in gate.get("reasons", [])
+    assert gate.get("status") == "near"
+
+
+def test_god_gate_honours_staging_overrides(monkeypatch):
+    monkeypatch.setattr(cfg, "STAGING_PROFILE", True, raising=False)
+    monkeypatch.setattr(cfg, "TEST_MODE", True, raising=False)
+    monkeypatch.setattr(cfg, "TEST_GOD_MAX_SE", 0.60, raising=False)
+    monkeypatch.setattr(cfg, "TEST_GOD_MIN_NORM", 9.4, raising=False)
+
+    state = _state(se=0.55)
+    tier = engine.map_tier(9.45, "long", state)
+    assert tier == "GOD"
+    gate = getattr(state, "_tier_meta", {}).get("god_gate", {})
+    assert gate.get("status") == "pass"
+    assert "se_high" not in gate.get("reasons", [])

--- a/tests/test_tier_short_cap.py
+++ b/tests/test_tier_short_cap.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+
+from skill_core.config import SHORT_TIER_CAP
+from skill_core.engine import map_tier
+
+
+def _state(**overrides):
+    base = {
+        "b_stable": 2,
+        "se": 0.18,
+        "items_by_level": {2: 6},
+        "accuracy_by_level": {2: 0.9},
+        "open_count": 2,
+        "open_ratings": [0.9, 0.85],
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_short_cap_blocks_ss():
+    state = _state()
+    tier = map_tier(9.7, "short", state)
+    assert tier == SHORT_TIER_CAP
+    meta = getattr(state, "_tier_meta", {})
+    assert meta.get("short_cap") is True
+    assert meta.get("base_tier") in {"S", "SS"}
+
+
+def test_short_cap_blocks_perfect_session():
+    state = _state()
+    tier = map_tier(10.0, "short", state)
+    assert tier == SHORT_TIER_CAP
+    meta = getattr(state, "_tier_meta", {})
+    assert meta.get("short_cap") is True

--- a/tests/test_variant_group.py
+++ b/tests/test_variant_group.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from skill_core.policy import DomainHistory, PolicyState, QuestionPolicy
+from skill_core.question_bank import DOMAINS
+
+from tests.conftest import build_synthetic_bank
+
+
+def test_variant_groups_not_reused_within_session():
+    bank = build_synthetic_bank()
+    target_domain = DOMAINS[0]
+
+    duplicates = [
+        it
+        for it in bank
+        if it.domain == target_domain and it.type == "MCQ" and it.difficulty == 0
+    ][:2]
+    for it in duplicates:
+        it.variant_group = f"{target_domain}_shared_vg"
+
+    policy = QuestionPolicy(bank, "long")
+    hist = {domain: DomainHistory() for domain in DOMAINS}
+    state = PolicyState(
+        run_type="long",
+        theta={domain: 0.0 for domain in DOMAINS},
+        se={domain: (1.5 if domain == target_domain else 0.1) for domain in DOMAINS},
+        asked=set(),
+        seen_variant_groups=set(),
+        step=0,
+        hist=hist,
+        info_history=[],
+    )
+
+    first = policy.next_item(state)
+    assert first is not None and first.domain == target_domain
+    vg_first = getattr(first, "variant_group", None)
+    state.step += 1
+    state.asked.add(first.id)
+    if vg_first:
+        state.seen_variant_groups.add(vg_first)
+    state.hist[target_domain].obj_count += 1
+    state.hist[target_domain].asked_ids.append(first.id)
+    state.last_domain_id = target_domain
+
+    second = policy.next_item(state)
+    assert second is not None and second.domain == target_domain
+    vg_second = getattr(second, "variant_group", None)
+    assert vg_second != vg_first, "Policy should not repeat variant groups within a session"
+

--- a/tools/fix_variant_groups.py
+++ b/tools/fix_variant_groups.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Assign provisional ``variant_group`` identifiers across bank shards."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import hashlib
+import json
+from pathlib import Path
+from typing import Callable, Iterable, Iterator
+
+
+DEFAULT_PATTERN = "data/**/*.{json,jsonl}"
+
+
+def _expand_pattern(pattern: str) -> Iterator[str]:
+    """Expand a glob pattern that may contain a single brace group."""
+
+    brace_start = pattern.find("{")
+    brace_end = pattern.find("}", brace_start + 1)
+    if brace_start != -1 and brace_end != -1 and brace_end > brace_start:
+        prefix = pattern[:brace_start]
+        suffix = pattern[brace_end + 1 :]
+        for option in pattern[brace_start + 1 : brace_end].split(","):
+            yield from _expand_pattern(f"{prefix}{option}{suffix}")
+        return
+    yield pattern
+
+
+def _iter_files(root: Path, pattern: str) -> list[Path]:
+    files: set[Path] = set()
+    for expanded in _expand_pattern(pattern):
+        expanded_path = Path(expanded)
+        if expanded_path.is_absolute():
+            matches = glob.glob(str(expanded_path), recursive=True)
+        else:
+            matches = glob.glob(str(root / expanded), recursive=True)
+        files.update(Path(m) for m in matches if Path(m).is_file())
+    return sorted(files)
+
+
+def _canonical_text(item: dict) -> str:
+    for key in ("stem", "prompt", "text", "question"):
+        val = item.get(key)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    fallback = item.get("id")
+    if isinstance(fallback, str) and fallback.strip():
+        return fallback.strip()
+    return ""
+
+
+def _compute_variant_group(item: dict) -> str:
+    domain = str(item.get("domain") or "Unknown").strip() or "Unknown"
+    if "type" in item and item["type"]:
+        typ = str(item["type"]).strip() or "MCQ"
+    else:
+        typ = "OPEN" if "rubric" in item else "MCQ"
+    diff = item.get("difficulty")
+    if diff is None:
+        diff = item.get("level", 0)
+    text = _canonical_text(item)
+    key = item.get("id") or text
+    token = hashlib.sha1(str(key).encode("utf-8")).hexdigest()[:10]
+    return f"{domain}:{typ}:{diff}:{token}"
+
+
+def _looks_like_item(node: object) -> bool:
+    if not isinstance(node, dict):
+        return False
+    if "id" not in node:
+        return False
+    keys = {"prompt", "stem", "text", "question", "type", "options", "choices", "rubric"}
+    return any(k in node for k in keys)
+
+
+def _collect_items(node: object) -> list[dict]:
+    items: list[dict] = []
+
+    def walk(obj: object) -> None:
+        if isinstance(obj, list):
+            for entry in obj:
+                walk(entry)
+            return
+        if isinstance(obj, dict):
+            if _looks_like_item(obj):
+                items.append(obj)
+            for value in obj.values():
+                walk(value)
+
+    walk(node)
+    return items
+
+
+def _load_items(path: Path) -> tuple[list[dict], Callable[[list[dict]], str], object]:
+    if path.suffix.lower() == ".jsonl":
+        lines = path.read_text(encoding="utf-8").splitlines()
+        items = [json.loads(line) for line in lines if line.strip()]
+
+        def writer(updated: list[dict]) -> str:
+            return "\n".join(json.dumps(entry, ensure_ascii=False) for entry in updated) + "\n"
+
+        return items, writer, items
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(raw, list):
+        def writer(updated: list[dict]) -> str:
+            return json.dumps(updated, indent=2, ensure_ascii=False) + "\n"
+
+        return raw, writer, raw
+
+    if isinstance(raw, dict):
+        items = _collect_items(raw)
+
+        def writer(updated: list[dict]) -> str:
+            # ``updated`` already mutates ``raw`` in place; serialize entire structure.
+            return json.dumps(raw, indent=2, ensure_ascii=False) + "\n"
+
+        return items, writer, raw
+
+    raise ValueError(f"Unsupported bank schema in {path}")
+
+
+def _apply_variant_groups(items: Iterable[dict]) -> tuple[int, int]:
+    fixed = 0
+    unchanged = 0
+    for item in items:
+        vg = item.get("variant_group")
+        if vg is None or not str(vg).strip():
+            item["variant_group"] = _compute_variant_group(item)
+            fixed += 1
+        else:
+            unchanged += 1
+    return fixed, unchanged
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Assign provisional variant_group IDs across bank shards")
+    parser.add_argument("--pattern", default=DEFAULT_PATTERN, help="glob pattern for bank files (default: %(default)s)")
+    parser.add_argument("--apply", action="store_true", help="write patched files alongside their sources")
+    args = parser.parse_args(argv)
+
+    root = Path(__file__).resolve().parents[1]
+    files = _iter_files(root, args.pattern)
+    if not files:
+        print("No bank files matched the pattern.")
+        return 0
+
+    total_items = 0
+    total_fixed = 0
+    total_unchanged = 0
+
+    for file_path in files:
+        items, writer, _raw = _load_items(file_path)
+        fixed, unchanged = _apply_variant_groups(items)
+        total_items += len(items)
+        total_fixed += fixed
+        total_unchanged += unchanged
+
+        output_path = Path(str(file_path) + ".patched" + file_path.suffix)
+        if args.apply:
+            output_path.write_text(writer(items), encoding="utf-8")
+            action = f"wrote {output_path}"
+        else:
+            action = "dry run"
+        print(f"{file_path}: total={len(items)} fixed={fixed} unchanged={unchanged} ({action})")
+
+    print(
+        f"Totals: files={len(files)} items={total_items} fixed={total_fixed} unchanged={total_unchanged}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add staging-only rubric overrides to the GOD gate configuration and derive effective thresholds per domain
- update the tier mapper to report distinct open_count_low versus open_rubric_low failures and expose them through the dev simulator
- extend the staging /dev/run overrides and regression tests to cover realistic GOD runs and rubric failures

## Testing
- PYTHONPATH=. pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e68bf2e798832fa082d383b89401f3